### PR TITLE
signs the absolute url

### DIFF
--- a/src/VerifyEmailHelper.php
+++ b/src/VerifyEmailHelper.php
@@ -47,7 +47,7 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
         $extraParams['token'] = $this->tokenGenerator->createToken($userId, $userEmail, $expiryTimestamp);
         $extraParams['expires'] = $expiryTimestamp;
 
-        $uri = $this->router->generate($routeName, $extraParams);
+        $uri = $this->router->generate($routeName, $extraParams, UrlGeneratorInterface::ABSOLUTE_URL);
         $signature = $this->uriSigner->sign($uri);
 
         /** @psalm-suppress PossiblyFalseArgument */

--- a/tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
+++ b/tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
@@ -45,7 +45,7 @@ final class VerifyEmailAcceptanceTest extends TestCase
 
         $expectedSignature = base64_encode(hash_hmac(
             'sha256',
-            sprintf('/verify/user?expires=%s&token=%s', $expiresAt, urlencode($expectedToken)),
+            sprintf('https://localhost/verify/user?expires=%s&token=%s', $expiresAt, urlencode($expectedToken)),
             'foo',
             true
         ));
@@ -55,7 +55,7 @@ final class VerifyEmailAcceptanceTest extends TestCase
 
         self::assertTrue(hash_equals($expectedSignature, $result['signature']));
         self::assertSame(
-            sprintf('/verify/user?expires=%s&signature=%s&token=%s', $expiresAt, urlencode($expectedSignature), urlencode($expectedToken)),
+            sprintf('https://localhost/verify/user?expires=%s&signature=%s&token=%s', $expiresAt, urlencode($expectedSignature), urlencode($expectedToken)),
             $signature
         );
     }

--- a/tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
+++ b/tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
@@ -45,7 +45,7 @@ final class VerifyEmailAcceptanceTest extends TestCase
 
         $expectedSignature = base64_encode(hash_hmac(
             'sha256',
-            sprintf('https://localhost/verify/user?expires=%s&token=%s', $expiresAt, urlencode($expectedToken)),
+            sprintf('http://localhost/verify/user?expires=%s&token=%s', $expiresAt, urlencode($expectedToken)),
             'foo',
             true
         ));
@@ -55,7 +55,7 @@ final class VerifyEmailAcceptanceTest extends TestCase
 
         self::assertTrue(hash_equals($expectedSignature, $result['signature']));
         self::assertSame(
-            sprintf('https://localhost/verify/user?expires=%s&signature=%s&token=%s', $expiresAt, urlencode($expectedSignature), urlencode($expectedToken)),
+            sprintf('http://localhost/verify/user?expires=%s&signature=%s&token=%s', $expiresAt, urlencode($expectedSignature), urlencode($expectedToken)),
             $signature
         );
     }


### PR DESCRIPTION
The url generator returns the absolute path for a route by default. We need to sign the absolute URL. 

closes #3 