### PR TITLE
[dev] use dev-master for the framework-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "require-dev": {
         "roave/security-advisories": "dev-master",
         "doctrine/orm": "^2.7",
+        "doctrine/persistence": "^1.3",
         "friendsofphp/php-cs-fixer": "^2.16",
         "symfony/framework-bundle": "^4.4 | ^5.0",
         "symfony/phpunit-bridge": "^5.0",


### PR DESCRIPTION
_only affects bundle development_

- ~fixed wrong use statements for `RoutingConfigurator`~ - no longer relevant

~and~

`doctrine/persistence` `1.3` is required by `symfony/framework-bundle` `dev-master`. `doctrine/orm` `2.7` uses `doctrine/persistence` `^1.2` where as `2.8-dev` uses `doctrine/persistence` `~1.2`, which blocks `1.3`. 

This PR essentially chooses to use the `master` branch of the `framework-bundle` with `orm 2.7` instead of using `framework-bundle 5.0.1` with `orm 2.8-dev`

```
  - Updating doctrine/persistence (1.2.x-dev 43526ae => 1.4.x-dev f5cf0d5):  Checking out f5cf0d59f5
  - Downgrading doctrine/orm (2.8.x-dev 3c91792 => 2.7.x-dev 70fb1ec):  Checking out 70fb1ecd78
  - Removing symfony/framework-bundle (v5.0.1)
  - Installing symfony/framework-bundle (dev-master 2f247eb): Cloning 2f247eb59d from cache
```