### PR TITLE
refactor names throughout the codebase

### DIFF
--- a/src/Model/VerifyEmailSignatureComponents.php
+++ b/src/Model/VerifyEmailSignatureComponents.php
@@ -33,7 +33,7 @@ final class VerifyEmailSignatureComponents
     /**
      * Returns the full signed URI that a user should use.
      */
-    public function getSignature(): string
+    public function getSignedUrl(): string
     {
         return $this->uri;
     }

--- a/src/VerifyEmailHelper.php
+++ b/src/VerifyEmailHelper.php
@@ -43,14 +43,15 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
     /**
      * {@inheritdoc}
      */
-    public function generateSignature(string $routeName, string $userId, string $userEmail, array $extraParams = []): VerifyEmailSignatureComponents
+    public function generateSignature(string $routeName, string $userId, string $userEmail, array $queryParams = []): VerifyEmailSignatureComponents
     {
         $expiryTimestamp = time() + $this->lifetime;
 
-        $extraParams['token'] = $this->tokenGenerator->createToken($userId, $userEmail, $expiryTimestamp);
-        $extraParams['expires'] = $expiryTimestamp;
+        $queryParams['token'] = $this->tokenGenerator->createToken($userId, $userEmail, $expiryTimestamp);
+        $queryParams['expires'] = $expiryTimestamp;
 
-        $uri = $this->router->generate($routeName, $extraParams, UrlGeneratorInterface::ABSOLUTE_URL);
+        $uri = $this->router->generate($routeName, $queryParams, UrlGeneratorInterface::ABSOLUTE_URL);
+
         $signature = $this->uriSigner->sign($uri);
 
         /** @psalm-suppress PossiblyFalseArgument */

--- a/src/VerifyEmailHelper.php
+++ b/src/VerifyEmailHelper.php
@@ -61,22 +61,22 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
     /**
      * {@inheritdoc}
      */
-    public function isValidSignature(string $signature, string $userId, string $userEmail): bool
+    public function isValidSignature(string $signedUrl, string $userId, string $userEmail): bool
     {
-        $expiresAt = $this->queryUtility->getExpiryTimeStamp($signature);
+        $expiresAt = $this->queryUtility->getExpiryTimeStamp($signedUrl);
 
         if ($expiresAt <= time()) {
             throw new ExpiredSignatureException();
         }
 
         $knownToken = $this->tokenGenerator->createToken($userId, $userEmail, $expiresAt);
-        $userToken = $this->queryUtility->getTokenFromQuery($signature);
+        $userToken = $this->queryUtility->getTokenFromQuery($signedUrl);
 
         if (!hash_equals($knownToken, $userToken)) {
             return false;
         }
 
-        return $this->uriSigner->check($signature);
+        return $this->uriSigner->check($signedUrl);
     }
 
     /**

--- a/src/VerifyEmailHelperInterface.php
+++ b/src/VerifyEmailHelperInterface.php
@@ -30,13 +30,13 @@ interface VerifyEmailHelperInterface
     /**
      * Validate a signed Url provided by the user.
      *
-     * @param string $signature the URI that was submitted by the user
+     * @param string $signedUrl the URI that was submitted by the user
      * @param string $userId    unique user identifier
      * @param string $userEmail the user's unique email address
      *
      * @throws ExpiredSignatureException
      */
-    public function isValidSignature(string $signature, string $userId, string $userEmail): bool;
+    public function isValidSignature(string $signedUrl, string $userId, string $userEmail): bool;
 
     /**
      * Get the length of time in seconds that a signed uri is valid.

--- a/src/VerifyEmailHelperInterface.php
+++ b/src/VerifyEmailHelperInterface.php
@@ -20,12 +20,12 @@ interface VerifyEmailHelperInterface
     /**
      * Get a signed Url that can be provided to a user.
      *
-     * @param string $routeName       name of route that will be used to verify users
-     * @param string $userId          unique user identifier
-     * @param string $userEmail       the user's email address
-     * @param array  $extraParameters any additional query string parameters that will be a part of the signed URL
+     * @param string $routeName   name of route that will be used to verify users
+     * @param string $userId      unique user identifier
+     * @param string $userEmail   the user's email address
+     * @param array  $queryParams any additional query string parameters that will be a part of the signed URL
      */
-    public function generateSignature(string $routeName, string $userId, string $userEmail, array $extraParameters = []): VerifyEmailSignatureComponents;
+    public function generateSignature(string $routeName, string $userId, string $userEmail, array $queryParams = []): VerifyEmailSignatureComponents;
 
     /**
      * Validate a signed Url provided by the user.

--- a/tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
+++ b/tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
@@ -36,7 +36,7 @@ final class VerifyEmailAcceptanceTest extends TestCase
 
         $components = $helper->generateSignature('verify-test', $user->id, $user->email);
 
-        $signature = $components->getSignature();
+        $signature = $components->getSignedUrl();
         $expiresAt = ($components->getExpiryTime())->getTimestamp();
 
         $expectedUserData = json_encode([$user->id, $user->email, $expiresAt]);

--- a/tests/FunctionalTests/VerifyEmailHelperFunctionalTest.php
+++ b/tests/FunctionalTests/VerifyEmailHelperFunctionalTest.php
@@ -55,7 +55,7 @@ class VerifyEmailHelperFunctionalTest extends TestCase
 
         $result = $this->getHelper()->generateSignature('app_verify_route', $user->id, $user->email);
 
-        $parsedUri = parse_url($result->getSignature());
+        $parsedUri = parse_url($result->getSignedUrl());
         parse_str($parsedUri['query'], $queryParams);
 
         $knownToken = $token;

--- a/tests/UnitTests/VerifyEmailHelperTest.php
+++ b/tests/UnitTests/VerifyEmailHelperTest.php
@@ -72,7 +72,7 @@ final class VerifyEmailHelperTest extends TestCase
         $helper = $this->getHelper();
         $components = $helper->generateSignature('app_verify_route', '1234', 'jr@rushlow.dev');
 
-        self::assertSame($expectedSignature, $components->getSignature());
+        self::assertSame($expectedSignature, $components->getSignedUrl());
     }
 
     public function testIsValidSignature(): void


### PR DESCRIPTION
- `VerifyEmailSignatureComponents::class` `getSignature()` => `getSignedUrl()` - method returns the absolute signed url, not just the signature.

- `VerifyEmailHelper/Interface::class`:
    - `generateSignature()`  args -
`array $extraParams` => `array $queryParams` - query params that will be signed, but not generated by the bundle.

    - `isValidSignature()` args -
`string $signature` => `string $signedUrl` - we validate the complete url, not the signature