### PR TITLE
removed helper method to get the expected lifetime of a signature

### DIFF
--- a/src/VerifyEmailHelper.php
+++ b/src/VerifyEmailHelper.php
@@ -79,12 +79,4 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
 
         return $this->uriSigner->check($signedUrl);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSignatureLifetime(): int
-    {
-        return $this->lifetime;
-    }
 }

--- a/src/VerifyEmailHelperInterface.php
+++ b/src/VerifyEmailHelperInterface.php
@@ -28,7 +28,7 @@ interface VerifyEmailHelperInterface
      * @param string $userEmail   the email that is being verified
      * @param array  $extraParams any additional parameters (route wildcards or query parameters)
      *                            that will be used when generating the route for
-     *                            signed URL.
+     *                            signed URL
      */
     public function generateSignature(string $routeName, string $userId, string $userEmail, array $extraParams = []): VerifyEmailSignatureComponents;
 

--- a/src/VerifyEmailHelperInterface.php
+++ b/src/VerifyEmailHelperInterface.php
@@ -57,9 +57,4 @@ interface VerifyEmailHelperInterface
      * @throws ExpiredSignatureException
      */
     public function isSignedUrlValid(string $signedUrl, string $userId, string $userEmail): bool;
-
-    /**
-     * Get the length of time in seconds that a signed uri is valid.
-     */
-    public function getSignatureLifetime(): int;
 }

--- a/tests/UnitTests/VerifyEmailHelperTest.php
+++ b/tests/UnitTests/VerifyEmailHelperTest.php
@@ -128,12 +128,6 @@ final class VerifyEmailHelperTest extends TestCase
         $helper->isSignedUrlValid($signature, '1234', 'jr@rushlow.dev');
     }
 
-    public function testGetLifetimeReturnsIntFromLifetimeProperty(): void
-    {
-        $helper = $this->getHelper();
-        self::assertSame(3600, $helper->getSignatureLifetime());
-    }
-
     private function getHelper(): VerifyEmailHelperInterface
     {
         return new VerifyEmailHelper($this->mockRouter, $this->mockSigner, $this->mockQueryUtility, $this->tokenGenerator, 3600);


### PR DESCRIPTION
`VerifyEmailSignatureComponents::class` has a method to retrieve the signature expiration