### PR TITLE
PHP 8 support in CI / Dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Set PHP Version
+        run: sudo update-alternatives --set php /usr/bin/php7.4
+
       - name: Checkout
         uses: actions/checkout@v2.0.0
 
       - name: Install PHP-CS-Fixer
-        run: composer global require friendsofphp/php-cs-fixer --prefer-dist --no-progress --no-suggest
+        run: composer global require friendsofphp/php-cs-fixer --prefer-dist --no-progress
 
       - name: Enforce coding standards
         run: $HOME/.composer/vendor/bin/php-cs-fixer fix --config $GITHUB_WORKSPACE/.php_cs.dist --diff --diff-format udiff --dry-run
@@ -36,11 +39,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Set PHP Version
+        run: sudo update-alternatives --set php /usr/bin/php7.4
+
       - name: Checkout
         uses: actions/checkout@v2.0.0
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
+        run: composer update --prefer-dist --no-progress
 
       - name: Analyze Source
         run: vendor/bin/psalm -c $GITHUB_WORKSPACE/psalm.xml
@@ -53,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['7.2', '7.3', '7.4', '8.0']
-        symfony-version: ['4.4.*', '5.0.*', '5.1.*', '5.2.*']
+        symfony-version: ['4.4.*', '5.2.*']
 
     steps:
       - name: Set PHP Version
@@ -85,7 +91,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer config minimum-stability stable
-          composer install --prefer-dist --no-progress --no-suggest
+          composer update --prefer-dist --no-progress
         env:
           SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
 
@@ -138,7 +144,7 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
+        run: composer update --prefer-dist --no-progress
 
       - name: Unit Tests
         run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite unit
@@ -189,7 +195,7 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: Install dependencies
-        run: composer update --prefer-lowest --prefer-dist --no-progress --no-suggest
+        run: composer update --prefer-lowest --prefer-dist --no-progress
 
       - name: Unit Tests
         run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite unit

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.7",
-        "doctrine/persistence": "^1.3",
-        "friendsofphp/php-cs-fixer": "^2.16",
+        "doctrine/persistence": "^2.0",
+        "friendsofphp/php-cs-fixer": "^2.17",
         "symfony/framework-bundle": "^4.4 | ^5.0",
         "symfony/phpunit-bridge": "^5.0",
-        "vimeo/psalm": "^3.8"
+        "vimeo/psalm": "^4.3"
     },
     "conflict": {
         "symfony/framework-bundle": "<4.4"

--- a/psalm.xml
+++ b/psalm.xml
@@ -35,7 +35,6 @@
         <MissingReturnType errorLevel="info" />
         <MissingPropertyType errorLevel="info" />
         <InvalidDocblock errorLevel="info" />
-        <MisplacedRequiredParam errorLevel="info" />
 
         <PropertyNotSetInConstructor errorLevel="info" />
         <MissingConstructor errorLevel="info" />


### PR DESCRIPTION
- Removes psalm's `MisplacedRequiredParam` issue which is no longer supported.
- Updates CI for Composer 2 usage
- CI runs for `php-cs-fixer` & `psalm` are forced to use PHP 7.4 until both packages fully support PHP 8

Bumps dev dependencies to versions that support PHP 8
- `doctrine/persistence`
- `php-cs-fixer`
- `psalm`