### PR TITLE
add Polish translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ find a change that break's semver, please create an issue.*
 
 ## NEXT
 
+## 1.3.0
+
+* [#56](https://github.com/SymfonyCasts/verify-email-bundle/pull/56) Add Polish translations
+
+## 1.2.0
+
 * [#52](https://github.com/SymfonyCasts/verify-email-bundle/pull/52) Add German translations
 * [#54](https://github.com/SymfonyCasts/verify-email-bundle/pull/54) Add Serbian translations
 * [#55](https://github.com/SymfonyCasts/verify-email-bundle/pull/55) Add French translations

--- a/src/Resources/translations/VerifyEmailBundle.pl.xlf
+++ b/src/Resources/translations/VerifyEmailBundle.pl.xlf
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file original="file.ext" source-language="en" datatype="plaintext">
+        <body>
+            <trans-unit id="1">
+                <source>%count% year|%count% years</source>
+                <target>%count% rok|%count% lata|%count% lat</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>%count% month|%count% months</source>
+                <target>%count% miesiąc|%count% miesiące|%count% miesięcy</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>%count% day|%count% days</source>
+                <target>%count% dzień|%count% dni|%count% dni</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>%count% hour|%count% hours</source>
+                <target>%count% godzinę|%count% godziny|%count% godzin</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>%count% minute|%count% minutes</source>
+                <target>%count% minutę|%count% minuty|%count% minut</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>


### PR DESCRIPTION
mirrors https://github.com/SymfonyCasts/reset-password-bundle/pull/149

Context:

`This link will expire in 1 year` which in Polish is `Link wygaśnie w ciągu 1 roku`
`This link will expire in 3 years` which in Polish is `Link wygaśnie w ciągu 3 lat`
`This link will expire in 5 years` which in Polish is `Link wygaśnie w ciągu 5 lat`
`This link will expire in 6 years` which in Polish is `Link wygaśnie w ciągu 6 lat`
`This link will expire in 17 years` which in Polish is `Link wygaśnie w ciągu 17 lat`

the same context applies for `month|months`, `day|days`, `hour|hours`, `minute|minutes`