### PR TITLE
Added Dutch translations (in intl-icu format)

### DIFF
--- a/src/Resources/translations/VerifyEmailBundle+intl-icu.nl.xlf
+++ b/src/Resources/translations/VerifyEmailBundle+intl-icu.nl.xlf
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file original="file.ext" source-language="en" datatype="plaintext">
+        <body>
+            <trans-unit id="1">
+                <source>%count% year|%count% years</source>
+                <target>{count, plural, =0 {0 jaar} one {1 jaar} other {# jaren}}</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>%count% month|%count% months</source>
+                <target>{count, plural, =0 {0 maanden} one {1 maand} other {# maanden}}</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>%count% day|%count% days</source>
+                <target>{count, plural, =0 {0 dagen} one {1 dag} other {# dagen}}</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>%count% hour|%count% hours</source>
+                <target>{count, plural, =0 {0 uur} one {1 uur} other {# uren}}</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>%count% minute|%count% minutes</source>
+                <target>{count, plural, =0 {0 minuten} one {1 minuut} other {# minuten}}</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>


### PR DESCRIPTION
Added Dutch translations. Because of the somewhat complex nature of the Dutch language (0 vs 1 vs many) I've chosen to use the `intl-icu` format as it (suppose to be/) is the new standard and has better support for the complex scenarios. And as the minimum requirements of the bundle are `symfony/*:^4.4` it should not be a problem. Also Christophe mentioned to it in https://github.com/SymfonyCasts/verify-email-bundle/pull/56#issuecomment-780758383. 

If we would refactor all translations in one go to the `icu-intl` format and first use the old notation, let me know I would adjust this PR.

As for the Dutchies who want to check this PR, I've used the 'rules' in https://taaladvies.net/taal/advies/vraag/511 to translate it (used in \SymfonyCasts\Bundle\VerifyEmail\Model\VerifyEmailSignatureComponents::getExpirationMessageKey()), see:

> Uitzonderingen op de algemene regel vormen de zelfstandige naamwoorden kwartier, uur en jaar. Die hebben in de genoemde combinaties gewoonlijk de enkelvoudsvorm.