### PR TITLE
[CI] run tests on ubuntu 18.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   composer-validate:
     name: Validate composer.json
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - name: Checkout
@@ -19,7 +19,7 @@ jobs:
 
   php-cs-fixer:
     name: Lint Bundle Source
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - name: Set PHP Version
@@ -36,7 +36,7 @@ jobs:
 
   psalm:
     name: Psalm Static Analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - name: Set PHP Version
@@ -53,7 +53,7 @@ jobs:
 
   stable-tests:
     name: Symfony Stable
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false
@@ -110,7 +110,7 @@ jobs:
 
   dev-main-tests:
     name: Symfony 5.x
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false
@@ -158,7 +158,7 @@ jobs:
 
   lowest-version-tests:
     name: Lowest dependencies
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Use ubuntu 1804 for tests that rely on PHP <7.4. Github released base image ubuntu-latest which uses ubuntu-20.04 - the 20.04 does not have PHP 7.0 - 7.3. Previously, ubuntu-latest was based on ubuntu-18.04