### PR TITLE
[ci] upgrade php-cs-fixer 2.x -> 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: composer global require friendsofphp/php-cs-fixer --prefer-dist --no-progress
 
       - name: Enforce coding standards
-        run: $HOME/.composer/vendor/bin/php-cs-fixer fix --config $GITHUB_WORKSPACE/.php_cs.dist --diff --diff-format udiff --dry-run
+        run: $HOME/.composer/vendor/bin/php-cs-fixer fix --config $GITHUB_WORKSPACE/.php-cs-fixer.dist.php --diff --dry-run
 
   psalm:
     name: Psalm Static Analysis

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -4,18 +4,14 @@ if (!file_exists(__DIR__.'/src') || !file_exists(__DIR__.'/tests')) {
     exit(0);
 }
 
-$finder = PhpCsFixer\Finder::create()
+$finder = (new \PhpCsFixer\Finder())
     ->in([__DIR__.'/src', __DIR__.'/tests'])
 ;
 
-return PhpCsFixer\Config::create()
+return (new \PhpCsFixer\Config())
     ->setRules(array(
         '@Symfony' => true,
         '@Symfony:risky' => true,
-        '@PHPUnit75Migration:risky' => true,
-        'array_syntax' => ['syntax' => 'short'],
-        'protected_to_private' => false,
-        'semicolon_after_instruction' => false,
         'phpdoc_to_comment' => false,
         'header_comment' => [
             'header' => <<<EOF

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
         "doctrine/orm": "^2.7",
         "doctrine/persistence": "^2.0",
-        "friendsofphp/php-cs-fixer": "^2.17",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "symfony/framework-bundle": "^4.4 | ^5.0",
         "symfony/phpunit-bridge": "^5.0",
         "vimeo/psalm": "^4.3"


### PR DESCRIPTION
- keeping `'phpdoc_to_comment' => false,` even though it contradicts the symfony rule set. This is an edge case introduced in https://github.com/SymfonyCasts/verify-email-bundle/commit/e587c86c1582052109471fc48cc61b6a40c93273