### PR TITLE
Fix 'An email must have a "From" or a "Sender" header.'

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ class RegistrationController extends AbstractController
             );
         
         $email = new TemplatedEmail();
+        $email->from('send@example.com');
         $email->to($user->getEmail());
         $email->htmlTemplate('registration/confirmation_email.html.twig');
         $email->context(['signedUrl' => $signatureComponents->getSignedUrl()]);


### PR DESCRIPTION
This commit modifies example code to fix 'An email must have a "From" or a "Sender" header.'

![error screenshot](https://user-images.githubusercontent.com/19984221/134766535-b431d2fc-acc4-4c06-9b86-b46f80d125c6.png)
