### PR TITLE
[ci] add support for symfony 5.4 and 6.0 in stable tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['7.2', '7.3', '7.4', '8.0']
-        symfony-version: ['4.4.*', '5.2.*']
+        symfony-version: ['4.4.*', '5.4.*', '6.0.*']
 
     steps:
       - name: Set PHP Version


### PR DESCRIPTION
- [ ] depends on the release of Symfony 5.4 & 6.0