### PR TITLE
allow deprecation contracts 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "symfony/dependency-injection": "^4.4 | ^5.0 | ^6.0",
         "symfony/http-kernel": "^4.4 | ^5.0 | ^6.0",
         "symfony/routing": "^4.4 | ^5.0 | ^6.0",
-        "symfony/deprecation-contracts": "^2.2"
+        "symfony/deprecation-contracts": "^2.2 | ^3.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.7",


### PR DESCRIPTION
Symfony 6.0 uses `symfony/deprecation-contracts` @ `^3.0`, we need to allow `2.2` && `3.0` then let composer decide which can be installed based off of the PHP version. Otherwise reset-password cannot be used w/ Symfony 6+