### PR TITLE
RFC: Add translations for exception reasons

### DIFF
--- a/src/Resources/translations/VerifyEmailBundle.en.xlf
+++ b/src/Resources/translations/VerifyEmailBundle.en.xlf
@@ -22,6 +22,18 @@
                 <source>%count% minute|%count% minutes</source>
                 <target>%count% minute|%count% minutes</target>
             </trans-unit>
+            <trans-unit id="6">
+                <source>The link to verify your email has expired. Please request a new link.</source>
+                <target>The link to verify your email has expired. Please request a new link.</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>The link to verify your email is invalid. Please request a new link.</source>
+                <target>The link to verify your email is invalid. Please request a new link.</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>The link to verify your email appears to be for a different account or email. Please request a new link.</source>
+                <target>The link to verify your email appears to be for a different account or email. Please request a new link.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
We did this for SymfonyCasts/reset-password-bundle, see https://github.com/SymfonyCasts/reset-password-bundle/pull/206

I suggest something similar here, then I'll create a PR to maker bundle to make it work as it's done with reset-password-bundle
