### PR TITLE
Replace deprecated totallyTyped=true with errorLevel=1

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="1"
+    errorLevel="2"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="3"
-    totallyTyped="true"
+    errorLevel="1"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"


### PR DESCRIPTION
Recently Psalm started failing with the next error:

```
ERROR: ConfigIssue - psalm.xml:4:5 - Attribute "totallyTyped" is deprecated and is going to be removed in the next major version (see https://psalm.dev/271)
    totallyTyped="true"


------------------------------
1 errors found
------------------------------
```

More information about the deprecation is here: https://github.com/vimeo/psalm/blob/f72f2f6fbe27b00c1fd8cd3ff8214a2d68fea14a/docs/running_psalm/configuration.md#totallytyped