### PR TITLE
Add optional lifetime to generateSignature

### DIFF
--- a/src/VerifyEmailHelper.php
+++ b/src/VerifyEmailHelper.php
@@ -46,10 +46,10 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
     /**
      * {@inheritdoc}
      */
-    public function generateSignature(string $routeName, string $userId, string $userEmail, array $extraParams = []): VerifyEmailSignatureComponents
+    public function generateSignature(string $routeName, string $userId, string $userEmail, array $extraParams = [], ?int $lifetime = null): VerifyEmailSignatureComponents
     {
         $generatedAt = time();
-        $expiryTimestamp = $generatedAt + $this->lifetime;
+        $expiryTimestamp = $generatedAt + ($lifetime ?: $this->lifetime);
 
         $extraParams['token'] = $this->tokenGenerator->createToken($userId, $userEmail);
         $extraParams['expires'] = $expiryTimestamp;


### PR DESCRIPTION
It would be useful to specify an optional lifetime when generating the signature, instead of using the config lifetime. I have a use case where I need the lifetime to be different from the default in the config.