### PR TITLE
feat: make signature generation more flexible by allowing relative URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,13 @@ _Optional_ - Defaults to `3600` seconds
 This is the length of time a signed URL is valid for in seconds after it has
 been created. 
 
+#### `use_relative_path`
+
+_Optional_ – Defaults to `false`
+
+If set to `true`, the generated verification URL will use a relative path instead of an absolute URL.
+This is useful if your app is accessible under multiple domains or customer-specific subdomains, as the host will be determined dynamically by the user's current request.
+
 ## Reserved Query Parameters
 
 If you add any extra query parameters in the 5th argument of `verifyEmailHelper::generateSignature()`,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,16 +6,6 @@ parameters:
 			path: src/DependencyInjection/Configuration.php
 
 		-
-			message: "#^Instantiated class Symfony\\\\Component\\\\HttpKernel\\\\UriSigner not found\\.$#"
-			count: 1
-			path: src/Factory/UriSignerFactory.php
-
-		-
-			message: "#^Method SymfonyCasts\\\\Bundle\\\\VerifyEmail\\\\Factory\\\\UriSignerFactory\\:\\:createUriSigner\\(\\) has invalid return type Symfony\\\\Component\\\\HttpKernel\\\\UriSigner\\.$#"
-			count: 1
-			path: src/Factory/UriSignerFactory.php
-
-		-
 			message: "#^Parameter \\#2 \\$data of function hash_hmac expects string, string\\|false given\\.$#"
 			count: 1
 			path: src/Generator/VerifyEmailTokenGenerator.php
@@ -44,16 +34,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\<string, int\\|string\\>\\|false given\\.$#"
 			count: 1
 			path: src/Util/VerifyEmailQueryUtility.php
-
-		-
-			message: "#^Call to method check\\(\\) on an unknown class Symfony\\\\Component\\\\HttpKernel\\\\UriSigner\\.$#"
-			count: 1
-			path: src/VerifyEmailHelper.php
-
-		-
-			message: "#^Call to method sign\\(\\) on an unknown class Symfony\\\\Component\\\\HttpKernel\\\\UriSigner\\.$#"
-			count: 1
-			path: src/VerifyEmailHelper.php
 
 		-
 			message: "#^Method SymfonyCasts\\\\Bundle\\\\VerifyEmail\\\\VerifyEmailHelper\\:\\:__construct\\(\\) has parameter \\$uriSigner with no type specified\\.$#"
@@ -86,7 +66,12 @@ parameters:
 			path: src/VerifyEmailHelper.php
 
 		-
-			message: "#^Property SymfonyCasts\\\\Bundle\\\\VerifyEmail\\\\VerifyEmailHelper\\:\\:\\$uriSigner has unknown class Symfony\\\\Component\\\\HttpKernel\\\\UriSigner as its type\\.$#"
+			message: "#^Property SymfonyCasts\\\\Bundle\\\\VerifyEmail\\\\VerifyEmailHelper\\:\\:\\$useRelativePath has no type specified\\.$#"
+			count: 1
+			path: src/VerifyEmailHelper.php
+
+		-
+			message: "#^Instanceof between Symfony\\\\Component\\\\HttpFoundation\\\\UriSigner and Symfony\\\\Component\\\\HttpFoundation\\\\UriSigner will always evaluate to true\\.$#"
 			count: 1
 			path: src/VerifyEmailHelper.php
 
@@ -97,41 +82,26 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property object\\:\\:\\$helper\\.$#"
-			count: 2
-			path: tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
-
-		-
-			message: "#^Call to method sign\\(\\) on an unknown class Symfony\\\\Component\\\\HttpKernel\\\\UriSigner\\.$#"
-			count: 1
+			count: 4
 			path: tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
 
 		-
 			message: "#^Parameter \\#2 \\$data of function hash_hmac expects string, string\\|false given\\.$#"
-			count: 2
+			count: 4
 			path: tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
 
 		-
-			message: "#^Parameter \\$uriSigner of method SymfonyCasts\\\\Bundle\\\\VerifyEmail\\\\Tests\\\\AcceptanceTests\\\\VerifyEmailAcceptanceFixture\\:\\:__construct\\(\\) has invalid type Symfony\\\\Component\\\\HttpKernel\\\\UriSigner\\.$#"
-			count: 1
+			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert::assertTrue\\(\\) with true and 'Test correctly does.*' will always evaluate to true\\.$#"
+			count: 3
 			path: tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
 
 		-
-			message: "#^Property SymfonyCasts\\\\Bundle\\\\VerifyEmail\\\\Tests\\\\AcceptanceTests\\\\VerifyEmailAcceptanceFixture\\:\\:\\$uriSigner has unknown class Symfony\\\\Component\\\\HttpKernel\\\\UriSigner as its type\\.$#"
+			message: "#^Method SymfonyCasts\\\\Bundle\\\\VerifyEmail\\\\Tests\\\\AcceptanceTests\\\\VerifyEmailAcceptanceTest\\:\\:getBootedKernel\\(\\) has parameter \\$customConfig with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
-
-		-
-			message: "#^Call to method sign\\(\\) on an unknown class Symfony\\\\Component\\\\HttpKernel\\\\UriSigner\\.$#"
-			count: 1
-			path: tests/FunctionalTests/VerifyEmailHelperFunctionalTest.php
 
 		-
 			message: "#^Cannot access offset 'query' on array\\{scheme\\?\\: string, host\\?\\: string, port\\?\\: int\\<0, 65535\\>, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\|false\\.$#"
-			count: 1
-			path: tests/FunctionalTests/VerifyEmailHelperFunctionalTest.php
-
-		-
-			message: "#^Instantiated class Symfony\\\\Component\\\\HttpKernel\\\\UriSigner not found\\.$#"
 			count: 1
 			path: tests/FunctionalTests/VerifyEmailHelperFunctionalTest.php
 
@@ -156,7 +126,7 @@ parameters:
 			path: tests/FunctionalTests/VerifyEmailHelperFunctionalTest.php
 
 		-
-			message: "#^Property SymfonyCasts\\\\Bundle\\\\VerifyEmail\\\\Tests\\\\FunctionalTests\\\\VerifyEmailHelperFunctionalTest\\:\\:\\$uriSigner has unknown class Symfony\\\\Component\\\\HttpKernel\\\\UriSigner as its type\\.$#"
+			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert::assertTrue\\(\\) with true and 'Test correctly does.*' will always evaluate to true\\.$#"
 			count: 1
 			path: tests/FunctionalTests/VerifyEmailHelperFunctionalTest.php
 
@@ -196,11 +166,6 @@ parameters:
 			path: tests/UnitTests/Model/VerifyEmailSignatureComponentsTest.php
 
 		-
-			message: "#^Class Symfony\\\\Component\\\\HttpKernel\\\\UriSigner not found\\.$#"
-			count: 1
-			path: tests/UnitTests/VerifyEmailHelperTest.php
-
-		-
 			message: "#^Property SymfonyCasts\\\\Bundle\\\\VerifyEmail\\\\Tests\\\\UnitTests\\\\VerifyEmailHelperTest\\:\\:\\$mockQueryUtility has no type specified\\.$#"
 			count: 1
 			path: tests/UnitTests/VerifyEmailHelperTest.php
@@ -226,6 +191,11 @@ parameters:
 			path: tests/VerifyEmailTestKernel.php
 
 		-
+			message: "#^Method SymfonyCasts\\\\Bundle\\\\VerifyEmail\\\\Tests\\\\VerifyEmailTestKernel\\:\\:__construct\\(\\) has parameter \\$customConfig with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/VerifyEmailTestKernel.php
+
+		-
 			message: "#^Property SymfonyCasts\\\\Bundle\\\\VerifyEmail\\\\Tests\\\\VerifyEmailTestKernel\\:\\:\\$builder has no type specified\\.$#"
 			count: 1
 			path: tests/VerifyEmailTestKernel.php
@@ -237,5 +207,10 @@ parameters:
 
 		-
 			message: "#^Property SymfonyCasts\\\\Bundle\\\\VerifyEmail\\\\Tests\\\\VerifyEmailTestKernel\\:\\:\\$routes has no type specified\\.$#"
+			count: 1
+			path: tests/VerifyEmailTestKernel.php
+
+		-
+			message: "#^Property SymfonyCasts\\\\Bundle\\\\VerifyEmail\\\\Tests\\\\VerifyEmailTestKernel\\:\\:\\$customConfig type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/VerifyEmailTestKernel.php

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -29,6 +29,10 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue(3600)
                     ->info('The length of time in seconds that a signed URI is valid for after it is created.')
                 ->end()
+                ->booleanNode('use_relative_path')
+                    ->defaultValue(false)
+                    ->info('Decides whether to use an absolute url or a relative path for signing.')
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/DependencyInjection/SymfonyCastsVerifyEmailExtension.php
+++ b/src/DependencyInjection/SymfonyCastsVerifyEmailExtension.php
@@ -34,6 +34,7 @@ final class SymfonyCastsVerifyEmailExtension extends Extension
 
         $helperDefinition = $container->getDefinition('symfonycasts.verify_email.helper');
         $helperDefinition->replaceArgument(4, $config['lifetime']);
+        $helperDefinition->replaceArgument(5, $config['use_relative_path']);
     }
 
     public function getAlias(): string

--- a/src/Resources/config/verify_email_services.xml
+++ b/src/Resources/config/verify_email_services.xml
@@ -28,6 +28,7 @@
             <argument type="service" id="symfonycasts.verify_email.query_utility" />
             <argument type="service" id="symfonycasts.verify_email.token_generator" />
             <argument /> <!-- verify user signature lifetime -->
+            <argument /> <!-- verify user signature path generation method -->
         </service>
     </services>
 </container>

--- a/src/VerifyEmailHelper.php
+++ b/src/VerifyEmailHelper.php
@@ -63,10 +63,11 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
         $extraParams['token'] = $this->tokenGenerator->createToken($userId, $userEmail);
         $extraParams['expires'] = $expiryTimestamp;
 
-        $uri = $this->router->generate($routeName, $extraParams, UrlGeneratorInterface::ABSOLUTE_URL);
+        $uri = $this->router->generate($routeName, $extraParams, $this->useRelativePath ? UrlGeneratorInterface::RELATIVE_PATH : UrlGeneratorInterface::ABSOLUTE_URL);
+        $signature = $this->uriSigner->sign($uri);
 
         /** @psalm-suppress PossiblyFalseArgument */
-        return new VerifyEmailSignatureComponents(\DateTimeImmutable::createFromFormat('U', (string) $expiryTimestamp), $this->getSignedUrl($uri), $generatedAt);
+        return new VerifyEmailSignatureComponents(\DateTimeImmutable::createFromFormat('U', (string) $expiryTimestamp), $signature, $generatedAt);
     }
 
     public function validateEmailConfirmation(string $signedUrl, string $userId, string $userEmail): void
@@ -112,56 +113,4 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
         }
     }
 
-    private function generateAbsolutePath(string $absoluteUri): string
-    {
-        $parsedUri = parse_url($absoluteUri);
-        \assert(\is_array($parsedUri), 'Could not parse the provided URI.');
-
-        $path = $parsedUri['path'] ?? '';
-        $query = $this->getQueryStringFromParsedUrl($parsedUri);
-        $fragment = isset($parsedUri['fragment']) ? '#'.$parsedUri['fragment'] : '';
-
-        return $path.$query.$fragment;
-    }
-
-    public function generateSigningString(string $uri): string
-    {
-        if (!$this->useRelativePath) {
-            return $uri;
-        }
-
-        return $this->generateAbsolutePath($uri);
-    }
-
-    private function generateBaseUrl(string $absoluteUri): string
-    {
-        $parsedUri = parse_url($absoluteUri);
-        $scheme = isset($parsedUri['scheme']) ? $parsedUri['scheme'].'://' : '';
-        $host = $parsedUri['host'] ?? '';
-
-        return $scheme.$host;
-    }
-
-    private function getSignedUrl(string $uri): string
-    {
-        $signature = $this->uriSigner->sign($this->generateSigningString($uri));
-
-        if (false === $this->useRelativePath) {
-            return $signature;
-        }
-
-        return $this->generateBaseUrl($uri).$signature;
-    }
-
-    /**
-     * @param array{scheme?: string, host?: string, port?: int, user?: string, pass?: string, query?: string, path?: string, fragment?: string} $parsedUrl
-     */
-    private function getQueryStringFromParsedUrl(array $parsedUrl): string
-    {
-        if (!\array_key_exists('query', $parsedUrl)) {
-            return '';
-        }
-
-        return $parsedUrl['query'] ? ('?'.$parsedUrl['query']) : '';
-    }
 }

--- a/tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
+++ b/tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
@@ -117,9 +117,83 @@ final class VerifyEmailAcceptanceTest extends TestCase
         $this->assertTrue(true, 'Test correctly does not throw an exception');
     }
 
-    private function getBootedKernel(): KernelInterface
+    public function testGenerateSignatureWithRelativePath(): void
+    {
+        $kernel = $this->getBootedKernel(['use_relative_path' => true]);
+
+        $container = $kernel->getContainer();
+
+        /** @var VerifyEmailHelper $helper */
+        $helper = $container->get(VerifyEmailAcceptanceFixture::class)->helper;
+
+        $components = $helper->generateSignature('verify-test', '1234', 'jr@rushlow.dev');
+
+        $signature = $components->getSignedUrl();
+
+        $expiresAt = $components->getExpiresAt()->getTimestamp();
+
+        $expectedUserData = json_encode(['1234', 'jr@rushlow.dev']);
+
+        $expectedToken = base64_encode(hash_hmac('sha256', $expectedUserData, 'foo', true));
+
+        $expectedSignature = base64_encode(hash_hmac(
+            'sha256',
+            \sprintf('/verify/user?expires=%s&token=%s', $expiresAt, urlencode($expectedToken)),
+            'foo',
+            true
+        ));
+
+        $parsed = parse_url($signature);
+
+        if (!\is_array($parsed) || !isset($parsed['query'])) {
+            throw new \RuntimeException('Invalid signature URL');
+        }
+
+        parse_str($parsed['query'], $result);
+
+        self::assertIsString($result['signature']);
+        self::assertTrue(hash_equals($expectedSignature, $result['signature']));
+        self::assertSame(
+            \sprintf('/verify/user?expires=%s&signature=%s&token=%s', $expiresAt, urlencode($expectedSignature), urlencode($expectedToken)),
+            strstr($signature, '/verify/user')
+        );
+    }
+
+    public function testValidateEmailSignatureWithRelativePath(): void
+    {
+        $kernel = $this->getBootedKernel(['use_relative_path' => true]);
+
+        $container = $kernel->getContainer();
+
+        /** @var VerifyEmailHelper $helper */
+        $helper = $container->get(VerifyEmailAcceptanceFixture::class)->helper;
+        $expires = new \DateTimeImmutable('+1 hour');
+
+        $uriToTest = \sprintf(
+            '/verify/user?%s',
+            http_build_query([
+                'expires' => $expires->getTimestamp(),
+                'token' => base64_encode(hash_hmac(
+                    'sha256',
+                    json_encode(['1234', 'jr@rushlow.dev']),
+                    'foo',
+                    true
+                )),
+            ])
+        );
+
+        $signature = base64_encode(hash_hmac('sha256', $uriToTest, 'foo', true));
+
+        $test = \sprintf('%s&signature=%s', $uriToTest, urlencode($signature));
+
+        $helper->validateEmailConfirmation($test, '1234', 'jr@rushlow.dev');
+        $this->assertTrue(true, 'Test correctly does not throw an exception');
+    }
+
+    private function getBootedKernel(array $customConfig = []): KernelInterface
     {
         $builder = new ContainerBuilder();
+
         $builder->autowire(VerifyEmailAcceptanceFixture::class)
             ->setPublic(true)
             ->setArgument(1, new Reference('symfonycasts.verify_email.uri_signer'))
@@ -128,7 +202,9 @@ final class VerifyEmailAcceptanceTest extends TestCase
 
         $kernel = new VerifyEmailTestKernel(
             $builder,
-            ['verify-test' => '/verify/user']
+            ['verify-test' => '/verify/user'],
+            [],
+            $customConfig
         );
 
         $kernel->boot();

--- a/tests/FunctionalTests/VerifyEmailHelperFunctionalTest.php
+++ b/tests/FunctionalTests/VerifyEmailHelperFunctionalTest.php
@@ -106,7 +106,7 @@ final class VerifyEmailHelperFunctionalTest extends TestCase
         return \sprintf('/verify?%s', $sortedParams);
     }
 
-    private function getHelper(): VerifyEmailHelperInterface
+    private function getHelper(bool $useRelativePath = false): VerifyEmailHelperInterface
     {
         if (class_exists(UriSigner::class)) {
             $this->uriSigner = new UriSigner('foo', 'signature');
@@ -119,7 +119,8 @@ final class VerifyEmailHelperFunctionalTest extends TestCase
             $this->uriSigner,
             new VerifyEmailQueryUtility(),
             new VerifyEmailTokenGenerator('foo'),
-            3600
+            3600,
+            $useRelativePath
         );
     }
 }

--- a/tests/VerifyEmailTestKernel.php
+++ b/tests/VerifyEmailTestKernel.php
@@ -29,16 +29,20 @@ class VerifyEmailTestKernel extends Kernel
     private $builder;
     private $routes;
     private $extraBundles;
+    /** @var array */
+    private $customConfig;
 
     /**
-     * @param array             $routes  Routes to be added to the container e.g. ['name' => 'path']
-     * @param BundleInterface[] $bundles Additional bundles to be registered e.g. [new Bundle()]
+     * @param array             $routes       Routes to be added to the container e.g. ['name' => 'path']
+     * @param BundleInterface[] $bundles      Additional bundles to be registered e.g. [new Bundle()]
+     * @param array             $customConfig Custom configuration to be loaded into the container
      */
-    public function __construct(?ContainerBuilder $builder = null, array $routes = [], array $bundles = [])
+    public function __construct(?ContainerBuilder $builder = null, array $routes = [], array $bundles = [], array $customConfig = [])
     {
         $this->builder = $builder;
         $this->routes = $routes;
         $this->extraBundles = $bundles;
+        $this->customConfig = $customConfig;
 
         parent::__construct('test', true);
     }
@@ -54,6 +58,7 @@ class VerifyEmailTestKernel extends Kernel
         );
     }
 
+    /** @noinspection PhpParamsInspection */
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         if (null === $this->builder) {
@@ -76,6 +81,10 @@ class VerifyEmailTestKernel extends Kernel
                     'http_method_override' => false,
                 ]
             );
+
+            if (!empty($this->customConfig)) {
+                $container->loadFromExtension('symfonycasts_verify_email', $this->customConfig);
+            }
 
             $container->register('kernel', static::class)
                 ->setPublic(true)


### PR DESCRIPTION
Here is the PR regarding this issue: https://github.com/SymfonyCasts/verify-email-bundle/issues/136

In the current implementation, the UriSigner always generates an absolute URL when signing. However, this might not be the desired behavior in some cases. 

This PR adds a configuration option (use_relative_path) to allow the use of relative URLs when generating signatures. By default, the option is set to false, which maintains the existing behavior of generating absolute URLs.