### PR TITLE
[1.x] use `UriSigner::checkRequest()` to validate signatures using a `Request` object

### DIFF
--- a/src/Util/VerifyEmailQueryUtility.php
+++ b/src/Util/VerifyEmailQueryUtility.php
@@ -15,6 +15,8 @@ namespace SymfonyCasts\Bundle\VerifyEmail\Util;
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
  *
+ * @deprecated since v1.17.0 - Remove in 2.0
+ *
  * @internal
  *
  * @final
@@ -23,6 +25,8 @@ class VerifyEmailQueryUtility
 {
     public function getTokenFromQuery(string $uri): string
     {
+        @trigger_deprecation('symfonycasts/verify-email-bundle', '1.17.0', 'This method is deprecated and will be removed in 2.0.');
+
         $params = $this->getQueryParams($uri);
 
         return $params['token'];
@@ -30,6 +34,8 @@ class VerifyEmailQueryUtility
 
     public function getExpiryTimestamp(string $uri): int
     {
+        @trigger_deprecation('symfonycasts/verify-email-bundle', '1.17.0', 'This method is deprecated and will be removed in 2.0.');
+
         $params = $this->getQueryParams($uri);
 
         if (empty($params['expires'])) {

--- a/src/Util/VerifyEmailQueryUtility.php
+++ b/src/Util/VerifyEmailQueryUtility.php
@@ -15,8 +15,6 @@ namespace SymfonyCasts\Bundle\VerifyEmail\Util;
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
  *
- * @deprecated since v1.17.0 - Remove in 2.0
- *
  * @internal
  *
  * @final

--- a/src/Util/VerifyEmailQueryUtility.php
+++ b/src/Util/VerifyEmailQueryUtility.php
@@ -25,6 +25,7 @@ class VerifyEmailQueryUtility
 {
     public function getTokenFromQuery(string $uri): string
     {
+        /** @psalm-suppress UndefinedFunction */
         @trigger_deprecation('symfonycasts/verify-email-bundle', '1.17.0', 'This method is deprecated and will be removed in 2.0.');
 
         $params = $this->getQueryParams($uri);
@@ -34,6 +35,7 @@ class VerifyEmailQueryUtility
 
     public function getExpiryTimestamp(string $uri): int
     {
+        /** @psalm-suppress UndefinedFunction */
         @trigger_deprecation('symfonycasts/verify-email-bundle', '1.17.0', 'This method is deprecated and will be removed in 2.0.');
 
         $params = $this->getQueryParams($uri);

--- a/src/VerifyEmailHelper.php
+++ b/src/VerifyEmailHelper.php
@@ -46,6 +46,11 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
         $this->queryUtility = $queryUtility;
         $this->tokenGenerator = $generator;
         $this->lifetime = $lifetime;
+
+        if (!$uriSigner instanceof UriSigner) {
+            /** @psalm-suppress UndefinedFunction */
+            @trigger_deprecation('symfonycasts/verify-email-bundle', '1.17.0', 'Not providing an instance of %s is deprecated. It will be required in v2.0', UriSigner::class);
+        }
     }
 
     public function generateSignature(string $routeName, string $userId, string $userEmail, array $extraParams = []): VerifyEmailSignatureComponents
@@ -87,6 +92,7 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
 
     public function validateEmailConfirmationFromRequest(Request $request, string $userId, string $userEmail): void
     {
+        /** @legacy - Remove in 2.0 */
         if (!$this->uriSigner instanceof UriSigner) {
             throw new \RuntimeException(sprintf('An instance of %s is required, provided by symfony/http-kernel >=6.4, to validate an email confirmation.', UriSigner::class));
         }

--- a/src/VerifyEmailHelper.php
+++ b/src/VerifyEmailHelper.php
@@ -66,6 +66,7 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
 
     public function validateEmailConfirmation(string $signedUrl, string $userId, string $userEmail): void
     {
+        /** @psalm-suppress UndefinedFunction */
         @trigger_deprecation('symfonycasts/verify-email-bundle', '1.17.0', '%s() is deprecated and will be removed in v2.0, use validateEmailConfirmationFromRequest() instead.', __METHOD__);
 
         if (!$this->uriSigner->check($signedUrl)) {

--- a/src/VerifyEmailHelper.php
+++ b/src/VerifyEmailHelper.php
@@ -48,7 +48,6 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
         $this->lifetime = $lifetime;
 
         if (!$uriSigner instanceof UriSigner) {
-            /** @psalm-suppress UndefinedFunction */
             @trigger_deprecation('symfonycasts/verify-email-bundle', '1.17.0', 'Not providing an instance of %s is deprecated. It will be required in v2.0', UriSigner::class);
         }
     }
@@ -71,7 +70,6 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
 
     public function validateEmailConfirmation(string $signedUrl, string $userId, string $userEmail): void
     {
-        /** @psalm-suppress UndefinedFunction */
         @trigger_deprecation('symfonycasts/verify-email-bundle', '1.17.0', '%s() is deprecated and will be removed in v2.0, use validateEmailConfirmationFromRequest() instead.', __METHOD__);
 
         if (!$this->uriSigner->check($signedUrl)) {

--- a/src/VerifyEmailHelper.php
+++ b/src/VerifyEmailHelper.php
@@ -9,6 +9,7 @@
 
 namespace SymfonyCasts\Bundle\VerifyEmail;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\HttpKernel\UriSigner as LegacyUriSigner;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -63,9 +64,15 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
         return new VerifyEmailSignatureComponents(\DateTimeImmutable::createFromFormat('U', (string) $expiryTimestamp), $signature, $generatedAt);
     }
 
-    public function validateEmailConfirmation(string $signedUrl, string $userId, string $userEmail): void
+    public function validateEmailConfirmation(string $signedUrl, string $userId, string $userEmail, ?Request $request = null): void
     {
-        if (!$this->uriSigner->check($signedUrl)) {
+        if ($this->uriSigner instanceof UriSigner && null !== $request) {
+            $isValid = $this->uriSigner->checkRequest($request);
+        } else {
+            $isValid = $this->uriSigner->check($signedUrl);
+        }
+
+        if (!$isValid) {
             throw new InvalidSignatureException();
         }
 

--- a/src/VerifyEmailHelper.php
+++ b/src/VerifyEmailHelper.php
@@ -48,6 +48,7 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
         $this->lifetime = $lifetime;
 
         if (!$uriSigner instanceof UriSigner) {
+            /** @psalm-suppress UndefinedFunction */
             @trigger_deprecation('symfonycasts/verify-email-bundle', '1.17.0', 'Not providing an instance of %s is deprecated. It will be required in v2.0', UriSigner::class);
         }
     }
@@ -70,6 +71,7 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
 
     public function validateEmailConfirmation(string $signedUrl, string $userId, string $userEmail): void
     {
+        /** @psalm-suppress UndefinedFunction */
         @trigger_deprecation('symfonycasts/verify-email-bundle', '1.17.0', '%s() is deprecated and will be removed in v2.0, use validateEmailConfirmationFromRequest() instead.', __METHOD__);
 
         if (!$this->uriSigner->check($signedUrl)) {

--- a/src/VerifyEmailHelper.php
+++ b/src/VerifyEmailHelper.php
@@ -88,7 +88,7 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
     public function validateEmailConfirmationFromRequest(Request $request, string $userId, string $userEmail): void
     {
         if (!$this->uriSigner instanceof UriSigner) {
-            throw new \RuntimeException('Use the other one instead');
+            throw new \RuntimeException(sprintf('An instance of %s is required, provided by symfony/http-kernel >=6.4, to validate an email confirmation.', UriSigner::class));
         }
 
         if (!$this->uriSigner->checkRequest($request)) {

--- a/src/VerifyEmailHelperInterface.php
+++ b/src/VerifyEmailHelperInterface.php
@@ -36,6 +36,8 @@ interface VerifyEmailHelperInterface
     public function generateSignature(string $routeName, string $userId, string $userEmail, array $extraParams = []): VerifyEmailSignatureComponents;
 
     /**
+     * @deprecated since v1.17.0, use validateEmailConfirmationFromRequest instead.
+     *
      * Validate a signed an email confirmation request.
      *
      * If something is wrong with the email confirmation, a

--- a/src/VerifyEmailHelperInterface.php
+++ b/src/VerifyEmailHelperInterface.php
@@ -9,6 +9,7 @@
 
 namespace SymfonyCasts\Bundle\VerifyEmail;
 
+use Symfony\Component\HttpFoundation\Request;
 use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailExceptionInterface;
 use SymfonyCasts\Bundle\VerifyEmail\Model\VerifyEmailSignatureComponents;
 
@@ -17,6 +18,8 @@ use SymfonyCasts\Bundle\VerifyEmail\Model\VerifyEmailSignatureComponents;
  *
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
+ *
+ * @method void validateEmailConfirmationFromRequest(Request $request, string $userId, string $userEmail)
  */
 interface VerifyEmailHelperInterface
 {

--- a/tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
+++ b/tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
@@ -12,6 +12,7 @@ namespace SymfonyCasts\Bundle\VerifyEmail\Tests\AcceptanceTests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\HttpKernel\KernelInterface;
 use SymfonyCasts\Bundle\VerifyEmail\Tests\VerifyEmailTestKernel;
 use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelper;
@@ -92,6 +93,9 @@ final class VerifyEmailAcceptanceTest extends TestCase
 
     public function testValidateUsingRequestObject(): void
     {
+        if (!class_exists(UriSigner::class)) {
+            $this->markTestSkipped('Requires symfony/http-foundation 6.4+');
+        }
         $container = $this->getBootedKernel()->getContainer();
 
         /** @var VerifyEmailHelper $helper */

--- a/tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
+++ b/tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
@@ -11,6 +11,7 @@ namespace SymfonyCasts\Bundle\VerifyEmail\Tests\AcceptanceTests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\KernelInterface;
 use SymfonyCasts\Bundle\VerifyEmail\Tests\VerifyEmailTestKernel;
 use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelper;
@@ -85,6 +86,35 @@ final class VerifyEmailAcceptanceTest extends TestCase
         $test = sprintf('%s&signature=%s', $uriToTest, urlencode($signature));
 
         $helper->validateEmailConfirmation($test, '1234', 'jr@rushlow.dev');
+        $this->assertTrue(true, 'Test correctly does not throw an exception');
+    }
+
+    public function testValidateUsingRequestObject(): void
+    {
+        $container = ($this->getBootedKernel())->getContainer();
+
+        /** @var VerifyEmailHelper $helper */
+        $helper = $container->get(VerifyEmailAcceptanceFixture::class)->helper;
+        $expires = new \DateTimeImmutable('+1 hour');
+
+        $uriToTest = sprintf(
+            'http://localhost/verify/user?%s',
+            http_build_query([
+                'expires' => $expires->getTimestamp(),
+                'token' => base64_encode(hash_hmac(
+                    'sha256',
+                    json_encode(['1234', 'jr@rushlow.dev']),
+                    'foo',
+                    true
+                )),
+            ])
+        );
+
+        $signature = base64_encode(hash_hmac('sha256', $uriToTest, 'foo', true));
+
+        $test = sprintf('%s&signature=%s', $uriToTest, urlencode($signature));
+
+        $helper->validateEmailConfirmationFromRequest(Request::create(uri: $test), '1234', 'jr@rushlow.dev');
         $this->assertTrue(true, 'Test correctly does not throw an exception');
     }
 

--- a/tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
+++ b/tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
@@ -58,6 +58,7 @@ final class VerifyEmailAcceptanceTest extends TestCase
         );
     }
 
+    /** @group legacy */
     public function testValidateEmailSignature(): void
     {
         $kernel = $this->getBootedKernel();
@@ -91,7 +92,7 @@ final class VerifyEmailAcceptanceTest extends TestCase
 
     public function testValidateUsingRequestObject(): void
     {
-        $container = ($this->getBootedKernel())->getContainer();
+        $container = $this->getBootedKernel()->getContainer();
 
         /** @var VerifyEmailHelper $helper */
         $helper = $container->get(VerifyEmailAcceptanceFixture::class)->helper;

--- a/tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
+++ b/tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
@@ -24,6 +24,11 @@ use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface;
  */
 final class VerifyEmailAcceptanceTest extends TestCase
 {
+    /**
+     * @legacy - Remove annotation in 2.0
+     *
+     * @group legacy
+     */
     public function testGenerateSignature(): void
     {
         $kernel = $this->getBootedKernel();

--- a/tests/FunctionalTests/VerifyEmailHelperFunctionalTest.php
+++ b/tests/FunctionalTests/VerifyEmailHelperFunctionalTest.php
@@ -65,6 +65,7 @@ final class VerifyEmailHelperFunctionalTest extends TestCase
         self::assertTrue(hash_equals($knownSignature, $testSignature));
     }
 
+    /** @group legacy */
     public function testValidSignature(): void
     {
         $testSignature = $this->getTestSignedUri();

--- a/tests/FunctionalTests/VerifyEmailHelperFunctionalTest.php
+++ b/tests/FunctionalTests/VerifyEmailHelperFunctionalTest.php
@@ -39,6 +39,11 @@ final class VerifyEmailHelperFunctionalTest extends TestCase
         $this->mockRouter = $this->createMock(UrlGeneratorInterface::class);
     }
 
+    /**
+     * @legacy - Remove annotation in 2.0
+     *
+     * @group legacy
+     */
     public function testGenerateSignature(): void
     {
         $token = $this->getTestToken();
@@ -65,7 +70,11 @@ final class VerifyEmailHelperFunctionalTest extends TestCase
         self::assertTrue(hash_equals($knownSignature, $testSignature));
     }
 
-    /** @group legacy */
+    /**
+     * @legacy - Remove annotation in 2.0
+     *
+     * @group legacy
+     */
     public function testValidSignature(): void
     {
         $testSignature = $this->getTestSignedUri();

--- a/tests/IntegrationTests/VerifyEmailBundleAutowireTest.php
+++ b/tests/IntegrationTests/VerifyEmailBundleAutowireTest.php
@@ -20,6 +20,11 @@ use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface;
  */
 final class VerifyEmailBundleAutowireTest extends TestCase
 {
+    /**
+     * @legacy - Remove annotation in 2.0
+     *
+     * @group legacy
+     */
     public function testVerifyEmailBundleInterfaceIsAutowiredByContainer(): void
     {
         $builder = new ContainerBuilder();

--- a/tests/IntegrationTests/VerifyEmailServiceDefinitionTest.php
+++ b/tests/IntegrationTests/VerifyEmailServiceDefinitionTest.php
@@ -33,6 +33,10 @@ final class VerifyEmailServiceDefinitionTest extends TestCase
 
     /**
      * @dataProvider bundleServiceDefinitionDataProvider
+     *
+     * @legacy - Remove annotation in 2.0
+     *
+     * @group legacy
      */
     public function testBundleServiceDefinitions(string $definition): void
     {

--- a/tests/UnitTests/Util/VerifyEmailQueryTest.php
+++ b/tests/UnitTests/Util/VerifyEmailQueryTest.php
@@ -15,6 +15,8 @@ use SymfonyCasts\Bundle\VerifyEmail\Util\VerifyEmailQueryUtility;
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
+ *
+ * @group legacy
  */
 final class VerifyEmailQueryTest extends TestCase
 {

--- a/tests/UnitTests/VerifyEmailHelperTest.php
+++ b/tests/UnitTests/VerifyEmailHelperTest.php
@@ -183,6 +183,11 @@ final class VerifyEmailHelperTest extends TestCase
 
     public function testValidationWithRequestThrowsEarlyOnInvalidSignature(): void
     {
+        /** @legacy - Remove conditional in 2.0 */
+        if (!class_exists(UriSigner::class)) {
+            $this->markTestSkipped('Requires symfony/http-foundation 6.4+');
+        }
+
         $request = Request::create('/verify?expires=1&signature=1234%token=xyz');
 
         $this->mockSigner
@@ -206,6 +211,11 @@ final class VerifyEmailHelperTest extends TestCase
 
     public function testExceptionThrownWithExpiredSignatureFromRequest(): void
     {
+        /** @legacy - Remove conditional in 2.0 */
+        if (!class_exists(UriSigner::class)) {
+            $this->markTestSkipped('Requires symfony/http-foundation 6.4+');
+        }
+
         $timestamp = (new \DateTimeImmutable('-1 seconds'))->getTimestamp();
         $signedUrl = '/?expires='.$timestamp;
 
@@ -226,6 +236,11 @@ final class VerifyEmailHelperTest extends TestCase
 
     public function testValidationFromRequestThrowsWithInvalidToken(): void
     {
+        /** @legacy - Remove conditional in 2.0 */
+        if (!class_exists(UriSigner::class)) {
+            $this->markTestSkipped('Requires symfony/http-foundation 6.4+');
+        }
+
         $request = Request::create('/verify?expires=99999999999999&token=badToken');
 
         $this->mockSigner

--- a/tests/UnitTests/VerifyEmailHelperTest.php
+++ b/tests/UnitTests/VerifyEmailHelperTest.php
@@ -82,6 +82,7 @@ final class VerifyEmailHelperTest extends TestCase
         self::assertSame($expectedSignedUrl, $components->getSignedUrl());
     }
 
+    /** @group legacy */
     public function testValidationThrowsEarlyOnInvalidSignature(): void
     {
         $signedUrl = '/verify?expires=1&signature=1234%token=xyz';
@@ -115,6 +116,7 @@ final class VerifyEmailHelperTest extends TestCase
         $helper->validateEmailConfirmation($signedUrl, '1234', 'jr@rushlow.dev');
     }
 
+    /** @group legacy */
     public function testExceptionThrownWithExpiredSignature(): void
     {
         $timestamp = (new \DateTimeImmutable('-1 seconds'))->getTimestamp();
@@ -139,6 +141,7 @@ final class VerifyEmailHelperTest extends TestCase
         $helper->validateEmailConfirmation($signedUrl, '1234', 'jr@rushlow.dev');
     }
 
+    /** @group legacy */
     public function testValidationThrowsWithInvalidToken(): void
     {
         $signedUrl = '/verify?token=badToken';

--- a/tests/UnitTests/VerifyEmailHelperTest.php
+++ b/tests/UnitTests/VerifyEmailHelperTest.php
@@ -50,6 +50,11 @@ final class VerifyEmailHelperTest extends TestCase
         $this->tokenGenerator = $this->createMock(VerifyEmailTokenGenerator::class);
     }
 
+    /**
+     * @legacy - Remove annotation in 2.0
+     *
+     * @group legacy
+     */
     public function testSignatureIsGenerated(): void
     {
         $expires = time() + 3600;


### PR DESCRIPTION
- add's a new `validateEmailConfirmationFromRequest()` to `VerifyEmailHelperInterface` & it's implementation.
- deprecates `validateEmailConfirmation()` in `VerifyEmailHelperInterface` & it's implementation.
- ~deprecates `VerifyEmailQueryUtility` as this is no longer needed in the new "fromRequest" helper method.~
- does _not_ deprecates the 3rd `$queryUtility` argument in the `VerifyEmailHelper::__construct()` method as this argument is not nullable`
- deprecates passing anything other than an instance of `UriSigner` as the `$uriSigner` argument in the `VerifyEmailHelper::__construct()` method.
- silences self deprecations (introduced by this PR) in tests using `@group legacy` annotations. This is basically our entire test suite. Work is already started in #159 that will remove these annotations and deprecations in 2.0. 

Doc's will be updated in #143 _after_ maker-bundle `#1464` is updated / merged to reflect the changes in this PR.

fixes #155 