### PR TITLE
[2.x] version bumps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ on:
 jobs:
     test:
         uses: SymfonyCasts/.github/.github/workflows/phpunit.yaml@main
+        with:
+            php-version-matrix: '[8.3]'
+            php-version-lowest: 8.3
 
     composer-validate:
         uses: SymfonyCasts/.github/.github/workflows/composer-validate.yaml@main
@@ -19,3 +22,5 @@ jobs:
 
     sca:
         uses: SymfonyCasts/.github/.github/workflows/psalm.yaml@main
+        with:
+            php: 8.3

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "symfony/dependency-injection": "^6.4.5 | ^7.0",
         "symfony/http-kernel": "^6.4.5 | ^7.0",
         "symfony/routing": "^6.4.5 | ^7.0",
-        "symfony/deprecation-contracts": "^3.0"
+        "symfony/deprecation-contracts": "^2.2 | ^3.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.7",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "doctrine/orm": "^2.7",
         "doctrine/persistence": "^2.0",
         "symfony/framework-bundle": "^6.4.5 | ^7.0",
-        "symfony/phpunit-bridge": "^6.4.5 | ^7.0"
+        "symfony/phpunit-bridge": "^6.4.5 | ^7.0.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -5,19 +5,19 @@
     "license": "MIT",
     "minimum-stability": "dev",
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.3",
         "ext-json": "*",
-        "symfony/config": "^5.4 | ^6.0 | ^7.0",
-        "symfony/dependency-injection": "^5.4 | ^6.0 | ^7.0",
-        "symfony/http-kernel": "^5.4 | ^6.0 | ^7.0",
-        "symfony/routing": "^5.4 | ^6.0 | ^7.0",
-        "symfony/deprecation-contracts": "^2.2 | ^3.0"
+        "symfony/config": "^6.4.5 | ^7.0",
+        "symfony/dependency-injection": "^6.4.5 | ^7.0",
+        "symfony/http-kernel": "^6.4.5 | ^7.0",
+        "symfony/routing": "^6.4.5 | ^7.0",
+        "symfony/deprecation-contracts": "^3.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.7",
         "doctrine/persistence": "^2.0",
-        "symfony/framework-bundle": "^5.4 | ^6.0 | ^7.0",
-        "symfony/phpunit-bridge": "^5.4 | ^6.0 | ^7.0"
+        "symfony/framework-bundle": "^6.4.5 | ^7.0",
+        "symfony/phpunit-bridge": "^6.4.5 | ^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Assumes the following: 
- VerifyEmail `1.x` will be maintained through the end of 2024 (coincide w/ Symfony 5.4 EOL && PHP 8.2 EOL)
- VerifyEmail `1.x` will transition to security fixes only soon-ish. I believe this is safe considering the stability demonstrated since the bundles inception.
- VerifyEmail `2.x` will be the `default` branch for the repo, all new features will be merged into `2.x`. This would happen sometime _after_ we merge #157 

Changes: 

- bumps PHP minimum  `8.3`. When `1.x` reaches EOL in November-ish 2024 (EOL for Symfony 5.4). PHP 8.2 will be security fixes only. PHP `8.4` is due out 2024. Setting `8.3` as the minimum feels "bleeding-edge" but I think this is ok with the release cadence of PHP and our timing with a `2.x` branch.

![image](https://github.com/SymfonyCasts/verify-email-bundle/assets/40327885/2e92b60f-1b51-486e-abcf-d41b7d391e46)

- Dropping Symfony `5.x` with a minimum `6.4.5` which is the current LTS.

- [ ] CI Config changes to allow for dropping PHP Versions