### PR TITLE
[2.x] inject UriSigner directly in the VerifyEmailHelper

### DIFF
--- a/src/Factory/UriSignerFactory.php
+++ b/src/Factory/UriSignerFactory.php
@@ -19,10 +19,8 @@ use Symfony\Component\HttpKernel\UriSigner as LegacyUriSigner;
  * Will become final && internal and ultimately removed in v2.0.
  *
  * @internal
- *
- * @final
  */
-class UriSignerFactory
+final class UriSignerFactory
 {
     public function __construct(
         #[\SensitiveParameter]

--- a/src/Resources/config/verify_email_services.xml
+++ b/src/Resources/config/verify_email_services.xml
@@ -11,13 +11,9 @@
 
         <service id="symfonycasts.verify_email.query_utility" class="SymfonyCasts\Bundle\VerifyEmail\Util\VerifyEmailQueryUtility" public="false" />
 
-        <service id="symfonycasts.verify_email.uri_signer_factory" class="SymfonyCasts\Bundle\VerifyEmail\Factory\UriSignerFactory">
+        <service id="symfonycasts.verify_email.uri_signer" class="Symfony\Component\HttpFoundation\UriSigner">
             <argument>%kernel.secret%</argument>
             <argument>signature</argument>
-        </service>
-
-        <service id="symfonycasts.verify_email.uri_signer" class="Symfony\Component\HttpFoundation\UriSigner">
-            <factory service="symfonycasts.verify_email.uri_signer_factory" method="createUriSigner" />
         </service>
 
         <service id="SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface" alias="symfonycasts.verify_email.helper" />

--- a/tests/IntegrationTests/VerifyEmailServiceDefinitionTest.php
+++ b/tests/IntegrationTests/VerifyEmailServiceDefinitionTest.php
@@ -25,7 +25,6 @@ final class VerifyEmailServiceDefinitionTest extends TestCase
         $prefix = 'symfonycasts.verify_email.';
 
         yield [$prefix.'query_utility'];
-        yield [$prefix.'uri_signer_factory'];
         yield [$prefix.'uri_signer'];
         yield [$prefix.'helper'];
         yield [$prefix.'token_generator'];


### PR DESCRIPTION
- We can inject the `UriSigner` directly into `VerifyEmailHelper` instead of using a factory to pick the correct service.
- We can remove xor deprecate the `UriSignerFactory` in a separate PR for `2.0` depending on what we do with #165 
- replace `@final` docBlock tag with `final` class keyword in `UriSignerFactory`