### PR TITLE
[1.x] UriSigner to become internal in 2.x

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,6 @@
+# Upgrade from 1.x to 2.0
+
+## UriSignerFactory
+
+- The `UriSignerFactory` became `@internal` & `@final`. This class should not be
+used.

--- a/src/Factory/UriSignerFactory.php
+++ b/src/Factory/UriSignerFactory.php
@@ -15,16 +15,20 @@ use Symfony\Component\HttpKernel\UriSigner as LegacyUriSigner;
 /**
  * @author Victor Bocharsky <victor@symfonycasts.com>
  * @author Ryan Weaver      <ryan@symfonycasts.com>
+ *
+ * Will become final && internal and ultimately removed in v2.0.
+ *
+ * @internal
+ *
+ * @final
  */
 class UriSignerFactory
 {
-    private $secret;
-    private $parameter;
-
-    public function __construct(string $secret, string $parameter = '_hash')
-    {
-        $this->secret = $secret;
-        $this->parameter = $parameter;
+    public function __construct(
+        #[\SensitiveParameter]
+        private string $secret,
+        private string $parameter = '_hash'
+    ) {
     }
 
     /**


### PR DESCRIPTION
- Adds `internal` & `final` docBlock to `UriSignerFactory`
- Refactor class to use constructor property promotion
- Adds `SensitiveParameter` attribute to `$secret` property. (Prevents stack trace leaks in PHP `>=8.2`)
- Init `UPGRADE.md` guide for BC changes coming in `v2.0`

The `UriSignerFactory` will no longer be needed in `v2.0`. The intent is to make this `internal` in `v2.0.0` then remove it in a later `v2.x` release. This should avoid having to deprecate it in `v2.0` then remove it in `v3.0` - while preserve BC for `v1.x`.

Precursor to #164 