### PR TITLE
[2.x] generatedAt is now required

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,3 +4,13 @@
 
 - The `UriSignerFactory` became `@internal` & `@final`. This class should not be
 used.
+
+## VerifyEmailSignatureComponents
+
+- Providing an `int` to the constructor parameter `$generatedAt` is now required
+when instantiating a new `VerifyEmailSignatureComponents` instance.
+
+```diff
+- public function __construct(\DateTimeInterface $expiresAt, string $uri, ?int $generatedAt = null)
++ public function __construct(\DateTimeInterface $expiresAt, string $uri, int $generatedAt)
+```

--- a/src/Model/VerifyEmailSignatureComponents.php
+++ b/src/Model/VerifyEmailSignatureComponents.php
@@ -35,15 +35,11 @@ final class VerifyEmailSignatureComponents
      */
     private $transInterval = 0;
 
-    public function __construct(\DateTimeInterface $expiresAt, string $uri, ?int $generatedAt = null)
+    public function __construct(\DateTimeInterface $expiresAt, string $uri, int $generatedAt)
     {
         $this->expiresAt = $expiresAt;
         $this->uri = $uri;
         $this->generatedAt = $generatedAt;
-
-        if (null === $generatedAt) {
-            $this->triggerDeprecation();
-        }
     }
 
     /**
@@ -128,18 +124,5 @@ final class VerifyEmailSignatureComponents
         $createdAtTime = \DateTimeImmutable::createFromFormat('U', (string) $this->generatedAt);
 
         return $this->expiresAt->diff($createdAtTime);
-    }
-
-    /**
-     * @psalm-suppress UndefinedFunction
-     */
-    private function triggerDeprecation(): void
-    {
-        trigger_deprecation(
-            'symfonycasts/verify-email-bundle',
-            '1.2',
-            'Initializing the %s without setting the "$generatedAt" constructor argument is deprecated. The default "null" will be removed in the future.',
-            self::class
-        );
     }
 }


### PR DESCRIPTION
- Change `$generatedAt` from being an _optional_ `null|int` constructor parameter to a _required_ `int` parameter when instantiating a `VerifyEmailSignatureComponents` instance

- Removes associated deprecation when passing `null` to the constructor