### PR TITLE
[2.x] remove potential `LogicException` from translation methods

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -14,3 +14,6 @@ when instantiating a new `VerifyEmailSignatureComponents` instance.
 - public function __construct(\DateTimeInterface $expiresAt, string $uri, ?int $generatedAt = null)
 + public function __construct(\DateTimeInterface $expiresAt, string $uri, int $generatedAt)
 ```
+
+- Method's `getExpirationMessageKey`, `getExpirationMessageData`, & `getExpiresAtIntervalInstance`
+no longer potentially throw a `LogicException`.

--- a/src/Model/VerifyEmailSignatureComponents.php
+++ b/src/Model/VerifyEmailSignatureComponents.php
@@ -26,7 +26,7 @@ final class VerifyEmailSignatureComponents
     private $uri;
 
     /**
-     * @var int|null timestamp when the signature was created
+     * @var int timestamp when the signature was created
      */
     private $generatedAt;
 
@@ -67,8 +67,6 @@ final class VerifyEmailSignatureComponents
      * <p>{{ components.expirationMessageKey|trans(components.expirationMessageData) }}</p>
      *
      * symfony/translation is required to translate into a non-English locale.
-     *
-     * @throws \LogicException
      */
     public function getExpirationMessageKey(): string
     {
@@ -98,9 +96,6 @@ final class VerifyEmailSignatureComponents
         }
     }
 
-    /**
-     * @throws \LogicException
-     */
     public function getExpirationMessageData(): array
     {
         $this->getExpirationMessageKey();
@@ -111,16 +106,10 @@ final class VerifyEmailSignatureComponents
     /**
      * Get the interval that the signature is valid for.
      *
-     * @throws \LogicException
-     *
      * @psalm-suppress PossiblyFalseArgument
      */
     public function getExpiresAtIntervalInstance(): \DateInterval
     {
-        if (null === $this->generatedAt) {
-            throw new \LogicException(sprintf('%s initialized without setting the $generatedAt timestamp.', self::class));
-        }
-
         $createdAtTime = \DateTimeImmutable::createFromFormat('U', (string) $this->generatedAt);
 
         return $this->expiresAt->diff($createdAtTime);


### PR DESCRIPTION
The `VerifyEmailSignatureComponents` `$generatedAt` property is always an `int` - we no longer need to throw a `LogicException` if the value is `null` in:

- `getExpirationMessageKey()`
- `getExpirationMessageData()`
- `getExpiresAtIntervalInstance()`

Consumers of this class do not need surround these methods with a `try`/`catch(\LogicException)` block.