### PR TITLE
RegistrationController uses constructor property promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,8 @@ use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailExceptionInterface;
 
 class RegistrationController extends AbstractController
 {
-    private EmailVerifier $emailVerifier;
-
-    public function __construct(EmailVerifier $emailVerifier)
+    public function __construct(private EmailVerifier $emailVerifier)
     {
-        $this->emailVerifier = $emailVerifier;
     }
 
     #[Route('/register', name: 'app_register')]


### PR DESCRIPTION
https://github.com/symfony/maker-bundle/pull/1464 changes `RegistrationController` to use constructor property promotion. Let's reflect that in the readme.