### PR TITLE
[2.x] stop passing QueryUtil to Helper constructor

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -9,6 +9,17 @@ used.
 
 - `__construct()` no longer has a `VerifyEmailQueryUtility $queryUtility` argument
 
+```diff
+ public function __construct(
+     private UrlGeneratorInterface $router,
+     private UriSigner $uriSigner,
+-    private VerifyEmailQueryUtility $queryUtility,
+     private VerifyEmailTokenGenerator $tokenGenerator,
+     private int $lifetime
+ ) {
+ }
+```
+
 - `VerifyEmailHelperInterface::validateEmailConfirmation()` is deprecated since
 `v1.17.0` and will be removed in `v2.0.0`. Use `validateEmailConfirmationFromRequest()`
 instead.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,6 +7,8 @@ used.
 
 ## VerifyEmailHelper
 
+- `__construct()` no longer has a `VerifyEmailQueryUtility $queryUtility` argument
+
 - `VerifyEmailHelperInterface::validateEmailConfirmation()` is deprecated since
 `v1.17.0` and will be removed in `v2.0.0`. Use `validateEmailConfirmationFromRequest()`
 instead.

--- a/src/DependencyInjection/SymfonyCastsVerifyEmailExtension.php
+++ b/src/DependencyInjection/SymfonyCastsVerifyEmailExtension.php
@@ -33,7 +33,7 @@ final class SymfonyCastsVerifyEmailExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $helperDefinition = $container->getDefinition('symfonycasts.verify_email.helper');
-        $helperDefinition->replaceArgument(4, $config['lifetime']);
+        $helperDefinition->replaceArgument(3, $config['lifetime']);
     }
 
     public function getAlias(): string

--- a/src/Resources/config/verify_email_services.xml
+++ b/src/Resources/config/verify_email_services.xml
@@ -9,8 +9,6 @@
             <argument>%kernel.secret%</argument>
         </service>
 
-        <service id="symfonycasts.verify_email.query_utility" class="SymfonyCasts\Bundle\VerifyEmail\Util\VerifyEmailQueryUtility" public="false" />
-
         <service id="symfonycasts.verify_email.uri_signer" class="Symfony\Component\HttpFoundation\UriSigner">
             <argument>%kernel.secret%</argument>
             <argument>signature</argument>
@@ -21,7 +19,6 @@
         <service id="symfonycasts.verify_email.helper" class="SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelper">
             <argument type="service" id="router" />
             <argument type="service" id="symfonycasts.verify_email.uri_signer" />
-            <argument type="service" id="symfonycasts.verify_email.query_utility" />
             <argument type="service" id="symfonycasts.verify_email.token_generator" />
             <argument /> <!-- verify user signature lifetime -->
         </service>

--- a/src/VerifyEmailHelper.php
+++ b/src/VerifyEmailHelper.php
@@ -17,7 +17,6 @@ use SymfonyCasts\Bundle\VerifyEmail\Exception\InvalidSignatureException;
 use SymfonyCasts\Bundle\VerifyEmail\Exception\WrongEmailVerifyException;
 use SymfonyCasts\Bundle\VerifyEmail\Generator\VerifyEmailTokenGenerator;
 use SymfonyCasts\Bundle\VerifyEmail\Model\VerifyEmailSignatureComponents;
-use SymfonyCasts\Bundle\VerifyEmail\Util\VerifyEmailQueryUtility;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
@@ -31,7 +30,6 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
     public function __construct(
         private UrlGeneratorInterface $router,
         private UriSigner $uriSigner,
-        private VerifyEmailQueryUtility $queryUtility,
         private VerifyEmailTokenGenerator $tokenGenerator,
         private int $lifetime
     ) {

--- a/tests/Functional/VerifyEmailHelperFunctionalTest.php
+++ b/tests/Functional/VerifyEmailHelperFunctionalTest.php
@@ -15,7 +15,6 @@ use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use SymfonyCasts\Bundle\VerifyEmail\Generator\VerifyEmailTokenGenerator;
-use SymfonyCasts\Bundle\VerifyEmail\Util\VerifyEmailQueryUtility;
 use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelper;
 use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface;
 
@@ -115,7 +114,6 @@ final class VerifyEmailHelperFunctionalTest extends TestCase
         return new VerifyEmailHelper(
             $this->mockRouter,
             new UriSigner('foo', 'signature'),
-            new VerifyEmailQueryUtility(),
             new VerifyEmailTokenGenerator('foo'),
             3600
         );

--- a/tests/Integration/VerifyEmailServiceDefinitionTest.php
+++ b/tests/Integration/VerifyEmailServiceDefinitionTest.php
@@ -24,7 +24,6 @@ final class VerifyEmailServiceDefinitionTest extends TestCase
     {
         $prefix = 'symfonycasts.verify_email.';
 
-        yield [$prefix.'query_utility'];
         yield [$prefix.'uri_signer'];
         yield [$prefix.'helper'];
         yield [$prefix.'token_generator'];

--- a/tests/Unit/VerifyEmailHelperTest.php
+++ b/tests/Unit/VerifyEmailHelperTest.php
@@ -19,7 +19,6 @@ use SymfonyCasts\Bundle\VerifyEmail\Exception\ExpiredSignatureException;
 use SymfonyCasts\Bundle\VerifyEmail\Exception\InvalidSignatureException;
 use SymfonyCasts\Bundle\VerifyEmail\Exception\WrongEmailVerifyException;
 use SymfonyCasts\Bundle\VerifyEmail\Generator\VerifyEmailTokenGenerator;
-use SymfonyCasts\Bundle\VerifyEmail\Util\VerifyEmailQueryUtility;
 use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelper;
 use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface;
 
@@ -33,7 +32,6 @@ final class VerifyEmailHelperTest extends TestCase
 {
     private RouterInterface|MockObject $mockRouter;
     private UriSigner|MockObject $mockSigner;
-    private VerifyEmailQueryUtility|MockObject $mockQueryUtility;
     private VerifyEmailTokenGenerator|MockObject $tokenGenerator;
 
     protected function setUp(): void
@@ -42,7 +40,6 @@ final class VerifyEmailHelperTest extends TestCase
 
         $this->mockRouter = $this->createMock(RouterInterface::class);
         $this->mockSigner = $this->createMock(UriSigner::class);
-        $this->mockQueryUtility = $this->createMock(VerifyEmailQueryUtility::class);
         $this->tokenGenerator = $this->createMock(VerifyEmailTokenGenerator::class);
     }
 
@@ -147,6 +144,6 @@ final class VerifyEmailHelperTest extends TestCase
 
     private function getHelper(): VerifyEmailHelperInterface
     {
-        return new VerifyEmailHelper($this->mockRouter, $this->mockSigner, $this->mockQueryUtility, $this->tokenGenerator, 3600);
+        return new VerifyEmailHelper($this->mockRouter, $this->mockSigner, $this->tokenGenerator, 3600);
     }
 }


### PR DESCRIPTION
The `VerifyEmailQueryUtil` is no longer needed by the helper. Let's stop requiring it as a constructor argument.