### PR TITLE
typehint array shape for generateSignature()'s `$extraParams`

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -25,6 +25,15 @@ class EmailVerifier
 }
 ```
 
+- `VerifyEmailHelperInterface::generateSignature(extraParams: [])` added the array
+shape expected for the `extraParams` argument.
+
+```diff
+- @param array $extraParams
++ @param array<string, int|string> $extraParams
+```
+
+
 ## VerifyEmailSignatureComponents
 
 - Providing an `int` to the constructor parameter `$generatedAt` is now required

--- a/src/VerifyEmailHelperInterface.php
+++ b/src/VerifyEmailHelperInterface.php
@@ -24,12 +24,12 @@ interface VerifyEmailHelperInterface
     /**
      * Get a signed Url that can be emailed to a user.
      *
-     * @param string $routeName   name of route that will be used to verify users
-     * @param string $userId      unique user identifier
-     * @param string $userEmail   the email that is being verified
-     * @param array  $extraParams any additional parameters (route wildcards or query parameters)
-     *                            that will be used when generating the route for
-     *                            signed URL
+     * @param string                    $routeName   name of route that will be used to verify users
+     * @param string                    $userId      unique user identifier
+     * @param string                    $userEmail   the email that is being verified
+     * @param array<string, int|string> $extraParams any additional parameters (route wildcards or query parameters)
+     *                                               that will be used when generating the route for
+     *                                               signed URL
      */
     public function generateSignature(string $routeName, string $userId, string $userEmail, array $extraParams = []): VerifyEmailSignatureComponents;
 


### PR DESCRIPTION
refs: #177 

```
34     Method SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface::generateSignature() has parameter $extraParams with no value type specified in iterable type array.
```