### PR TITLE
typehint array shape for `getExpirationMessageData()` return value

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -37,3 +37,10 @@ when instantiating a new `VerifyEmailSignatureComponents` instance.
 
 - Method's `getExpirationMessageKey`, `getExpirationMessageData`, & `getExpiresAtIntervalInstance`
 no longer potentially throw a `LogicException`.
+
+- Added array shape typehint for the return value of `getExpirationMessageData()`
+
+```diff
+- @return array
++ @return array<string, int>
+```

--- a/src/Model/VerifyEmailSignatureComponents.php
+++ b/src/Model/VerifyEmailSignatureComponents.php
@@ -84,6 +84,9 @@ final class VerifyEmailSignatureComponents
         }
     }
 
+    /**
+     * @return array<string, int>
+     */
     public function getExpirationMessageData(): array
     {
         $this->getExpirationMessageKey();


### PR DESCRIPTION
refs: #177

```
 87     Method SymfonyCasts\Bundle\VerifyEmail\Model\VerifyEmailSignatureComponents::getExpirationMessageData() return type has no value type specified in iterable type array.
```