### PR TITLE
throw exception when unable to create DateTimeImmutable instance or encode json

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -46,7 +46,7 @@ shape expected for the `extraParams` argument.
 + @param array<string, int|string> $extraParams
 ```
 
-- `generateSignatur()` now throws a `VerifyEmailRuntimeException` if unable to create a `DateTimeInterface`
+- `generateSignature()` now throws a `VerifyEmailRuntimeException` if unable to create a `DateTimeInterface`
 instance from the sum of a timestamp and the `$lifetime` value passed to the class constructor
 
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -46,6 +46,9 @@ shape expected for the `extraParams` argument.
 + @param array<string, int|string> $extraParams
 ```
 
+- `generateSignatur()` now throws a `VerifyEmailRuntimeException` if unable to create a `DateTimeInterface`
+instance from the sum of a timestamp and the `$lifetime` value passed to the class constructor
+
 
 ## VerifyEmailSignatureComponents
 
@@ -58,7 +61,8 @@ when instantiating a new `VerifyEmailSignatureComponents` instance.
 ```
 
 - Method's `getExpirationMessageKey`, `getExpirationMessageData`, & `getExpiresAtIntervalInstance`
-no longer potentially throw a `LogicException`.
+no longer potentially throw a `LogicException`. They now throw a `VerifyEmailRuntimeException`
+if an invalid `$generatedAt` timestamp is provided to the class constructor.
 
 - Added array shape typehint for the return value of `getExpirationMessageData()`
 
@@ -66,3 +70,8 @@ no longer potentially throw a `LogicException`.
 - @return array
 + @return array<string, int>
 ```
+
+## VerifyEmailTokenGenerator
+
+- Method `createToken()` now throws a `VerifyEmailRuntimeException` if unable to `json_encode()` the
+  `$userId` & `$email` arguments.

--- a/src/Exception/VerifyEmailRuntimeException.php
+++ b/src/Exception/VerifyEmailRuntimeException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the SymfonyCasts VerifyEmailBundle package.
+ * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SymfonyCasts\Bundle\VerifyEmail\Exception;
+
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ */
+final class VerifyEmailRuntimeException extends \RuntimeException implements VerifyEmailExceptionInterface
+{
+    public function getReason(): string
+    {
+        return $this->getMessage();
+    }
+}

--- a/src/Generator/VerifyEmailTokenGenerator.php
+++ b/src/Generator/VerifyEmailTokenGenerator.php
@@ -9,6 +9,8 @@
 
 namespace SymfonyCasts\Bundle\VerifyEmail\Generator;
 
+use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailRuntimeException;
+
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
@@ -30,10 +32,16 @@ class VerifyEmailTokenGenerator
 
     /**
      * Get a cryptographically secure token.
+     *
+     * @throws VerifyEmailRuntimeException
      */
     public function createToken(string $userId, string $email): string
     {
-        $encodedData = json_encode([$userId, $email]);
+        try {
+            $encodedData = json_encode([$userId, $email], \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            throw new VerifyEmailRuntimeException(message: 'Unable to create token. Invalid JSON.', previous: $exception);
+        }
 
         return base64_encode(hash_hmac('sha256', $encodedData, $this->signingKey, true));
     }

--- a/src/Model/VerifyEmailSignatureComponents.php
+++ b/src/Model/VerifyEmailSignatureComponents.php
@@ -106,7 +106,7 @@ final class VerifyEmailSignatureComponents
         $createdAtTime = \DateTimeImmutable::createFromFormat('U', (string) $this->generatedAt);
 
         if (false === $createdAtTime) {
-            throw new VerifyEmailRuntimeException(sprintf('Unable to create DateTimeInterface from: %s', $this->generatedAt));
+            throw new VerifyEmailRuntimeException(sprintf('Unable to create DateTimeInterface instance from "generatedAt": %s', $this->generatedAt));
         }
 
         return $this->expiresAt->diff($createdAtTime);

--- a/src/Model/VerifyEmailSignatureComponents.php
+++ b/src/Model/VerifyEmailSignatureComponents.php
@@ -9,6 +9,8 @@
 
 namespace SymfonyCasts\Bundle\VerifyEmail\Model;
 
+use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailRuntimeException;
+
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
@@ -97,11 +99,15 @@ final class VerifyEmailSignatureComponents
     /**
      * Get the interval that the signature is valid for.
      *
-     * @psalm-suppress PossiblyFalseArgument
+     * @throws VerifyEmailRuntimeException
      */
     public function getExpiresAtIntervalInstance(): \DateInterval
     {
         $createdAtTime = \DateTimeImmutable::createFromFormat('U', (string) $this->generatedAt);
+
+        if (false === $createdAtTime) {
+            throw new VerifyEmailRuntimeException(sprintf('Unable to create DateTimeInterface from: %s', $this->generatedAt));
+        }
 
         return $this->expiresAt->diff($createdAtTime);
     }

--- a/src/VerifyEmailHelper.php
+++ b/src/VerifyEmailHelper.php
@@ -36,6 +36,9 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
     ) {
     }
 
+    /**
+     * @throws VerifyEmailRuntimeException
+     */
     public function generateSignature(string $routeName, string $userId, string $userEmail, array $extraParams = []): VerifyEmailSignatureComponents
     {
         $generatedAt = time();


### PR DESCRIPTION
- `VerifyEmailTokenGenerator::createToken()` now throws a `VerifyEmailRuntimeException` if `json_encode()` throws an error when encoding `$userId` & `$email`

- `VerifyEmailSignatureComponents::_multiple_methods_` & `VerifyEmailHelper::generateSignatur()` throw a `VerifyEmailRuntimeException` when unable to create a `DateTimeImmutable` instance

refs #177
