### PR TITLE
[dx] keep tooling in one place

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
         "doctrine/orm": "^2.7",
         "doctrine/persistence": "^2.0",
         "symfony/framework-bundle": "^5.4 | ^6.0 | ^7.0",
-        "symfony/phpunit-bridge": "^5.4 | ^6.0 | ^7.0",
-        "phpstan/phpstan": "^1.11.x-dev"
+        "symfony/phpunit-bridge": "^5.4 | ^6.0 | ^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -31,6 +30,17 @@
         }
     },
     "scripts": {
-        "phpstan": "vendor/bin/phpstan"
+        "tools:upgrade": [
+            "@tools:upgrade:php-cs-fixer",
+            "@tools:upgrade:phpstan"
+        ],
+        "tools:upgrade:php-cs-fixer": "composer upgrade -W -d tools/php-cs-fixer",
+        "tools:upgrade:phpstan": "composer upgrade -W -d tools/phpstan",
+        "tools:run": [
+            "@tools:run:php-cs-fixer",
+            "@tools:run:phpstan"
+        ],
+        "tools:run:php-cs-fixer": "tools/php-cs-fixer/vendor/bin/php-cs-fixer fix",
+        "tools:run:phpstan": "tools/phpstan/vendor/bin/phpstan --memory-limit=1G"
     }
 }

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,2 @@
+**/vendor
+**/composer.lock

--- a/tools/php-cs-fixer/composer.json
+++ b/tools/php-cs-fixer/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "friendsofphp/php-cs-fixer": "^3"
+    }
+}

--- a/tools/phpstan/composer.json
+++ b/tools/phpstan/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "phpstan/phpstan": "^1"
+    }
+}


### PR DESCRIPTION
- `composer tools:run` runs `php-cs-fixer` & `phpstan`
- `composer tools:run:php-cs-fixer` run only `php-cs-fixer` (works for `phpstan` as well).
- `composer tools:upgrade` upgrades / installs all of the `tools/*`
- `composer tools:upgrade:php-cs-fixer` Upgrades / installs only `php-cs-fixer` (works for `phpstan` as well)