### PR TITLE
Fix typos in FR translations

### DIFF
--- a/src/Resources/translations/VerifyEmailBundle.fr.xlf
+++ b/src/Resources/translations/VerifyEmailBundle.fr.xlf
@@ -24,15 +24,15 @@
             </trans-unit>
             <trans-unit id="6">
                 <source>The link to verify your email has expired. Please request a new link.</source>
-                <target>Le lien pour vérifier votre adresse e-mail a expiré. Veuillez refaire une demande de réinitialisation.</target>
+                <target>Le lien pour vérifier votre adresse e-mail a expiré. Veuillez demander un nouveau lien.</target>
             </trans-unit>
             <trans-unit id="7">
                 <source>The link to verify your email is invalid. Please request a new link.</source>
-                <target>Le lien pour vérifier votre adresse e-mail est invalide. Veuillez refaire une demande de réinitialisation.</target>
+                <target>Le lien pour vérifier votre adresse e-mail est invalide. Veuillez demander un nouveau lien.</target>
             </trans-unit>
             <trans-unit id="8">
                 <source>The link to verify your email appears to be for a different account or email. Please request a new link.</source>
-                <target>Le lien permettant de vérifier votre adresse e-mail semble correspondre à un autre compte ou e-mail. Veuillez refaire une demande de réinitialisation.</target>
+                <target>Le lien permettant de vérifier votre adresse e-mail semble correspondre à un autre compte ou e-mail. Veuillez demander un nouveau lien.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
The error messages mention a reset (🇫🇷 "réinitialisation") link—maybe from the ResetPasswordBundle? Updated it to "verification" (🇫🇷 "vérification").