### PR TITLE
feat: declare strict types and support php 8.4

### DIFF
--- a/src/Exception/ExpiredSignatureException.php
+++ b/src/Exception/ExpiredSignatureException.php
@@ -1,19 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the SymfonyCasts VerifyEmailBundle package.
  * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace SymfonyCasts\Bundle\VerifyEmail\Exception;
+
+use Exception;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
  */
-final class ExpiredSignatureException extends \Exception implements VerifyEmailExceptionInterface
+final class ExpiredSignatureException extends Exception implements VerifyEmailExceptionInterface
 {
     public function getReason(): string
     {

--- a/src/Exception/InvalidSignatureException.php
+++ b/src/Exception/InvalidSignatureException.php
@@ -1,19 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the SymfonyCasts VerifyEmailBundle package.
  * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace SymfonyCasts\Bundle\VerifyEmail\Exception;
+
+use Exception;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
  */
-final class InvalidSignatureException extends \Exception implements VerifyEmailExceptionInterface
+final class InvalidSignatureException extends Exception implements VerifyEmailExceptionInterface
 {
     public function getReason(): string
     {

--- a/src/Exception/VerifyEmailExceptionInterface.php
+++ b/src/Exception/VerifyEmailExceptionInterface.php
@@ -1,13 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the SymfonyCasts VerifyEmailBundle package.
  * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace SymfonyCasts\Bundle\VerifyEmail\Exception;
+
+use Throwable;
 
 /**
  * An exception that is thrown by VerifyEmailHelperInterface::validateEmailConfirmation().
@@ -15,7 +18,7 @@ namespace SymfonyCasts\Bundle\VerifyEmail\Exception;
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
  */
-interface VerifyEmailExceptionInterface extends \Throwable
+interface VerifyEmailExceptionInterface extends Throwable
 {
     /**
      * Returns a safe string that describes why verification failed.

--- a/src/Exception/VerifyEmailRuntimeException.php
+++ b/src/Exception/VerifyEmailRuntimeException.php
@@ -1,18 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the SymfonyCasts VerifyEmailBundle package.
  * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace SymfonyCasts\Bundle\VerifyEmail\Exception;
+
+use RuntimeException;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
  */
-final class VerifyEmailRuntimeException extends \RuntimeException implements VerifyEmailExceptionInterface
+final class VerifyEmailRuntimeException extends RuntimeException implements VerifyEmailExceptionInterface
 {
     public function getReason(): string
     {

--- a/src/Exception/WrongEmailVerifyException.php
+++ b/src/Exception/WrongEmailVerifyException.php
@@ -1,19 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the SymfonyCasts VerifyEmailBundle package.
  * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace SymfonyCasts\Bundle\VerifyEmail\Exception;
+
+use Exception;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
  */
-final class WrongEmailVerifyException extends \Exception implements VerifyEmailExceptionInterface
+final class WrongEmailVerifyException extends Exception implements VerifyEmailExceptionInterface
 {
     public function getReason(): string
     {

--- a/src/Factory/UriSignerFactory.php
+++ b/src/Factory/UriSignerFactory.php
@@ -1,14 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the SymfonyCasts VerifyEmailBundle package.
  * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace SymfonyCasts\Bundle\VerifyEmail\Factory;
 
+use SensitiveParameter;
 use Symfony\Component\HttpFoundation\UriSigner;
 
 /**
@@ -19,10 +21,11 @@ use Symfony\Component\HttpFoundation\UriSigner;
  *
  * @internal
  */
-final class UriSignerFactory
+final readonly class UriSignerFactory
 {
     public function __construct(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
+        
         private string $secret,
         private string $parameter = '_hash',
     ) {

--- a/src/Generator/VerifyEmailTokenGenerator.php
+++ b/src/Generator/VerifyEmailTokenGenerator.php
@@ -1,14 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the SymfonyCasts VerifyEmailBundle package.
  * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace SymfonyCasts\Bundle\VerifyEmail\Generator;
 
+use SensitiveParameter;
+use JsonException;
 use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailRuntimeException;
 
 /**
@@ -25,8 +28,8 @@ class VerifyEmailTokenGenerator
      * @param string $signingKey Unique, random, cryptographically secure string
      */
     public function __construct(
-        #[\SensitiveParameter]
-        private string $signingKey,
+        #[SensitiveParameter]
+        private readonly string $signingKey,
     ) {
     }
 
@@ -39,8 +42,8 @@ class VerifyEmailTokenGenerator
     {
         try {
             $encodedData = json_encode([$userId, $email], \JSON_THROW_ON_ERROR);
-        } catch (\JsonException $exception) {
-            throw new VerifyEmailRuntimeException(message: 'Unable to create token. Invalid JSON.', previous: $exception);
+        } catch (JsonException $jsonException) {
+            throw new VerifyEmailRuntimeException(message: 'Unable to create token. Invalid JSON.', previous: $jsonException);
         }
 
         return base64_encode(hash_hmac('sha256', $encodedData, $this->signingKey, true));

--- a/src/Model/VerifyEmailSignatureComponents.php
+++ b/src/Model/VerifyEmailSignatureComponents.php
@@ -1,14 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the SymfonyCasts VerifyEmailBundle package.
  * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace SymfonyCasts\Bundle\VerifyEmail\Model;
 
+use DateTimeInterface;
+use DateInterval;
+use DateTimeImmutable;
 use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailRuntimeException;
 
 /**
@@ -26,9 +30,9 @@ final class VerifyEmailSignatureComponents
      * @param int $generatedAt timestamp when the signature was created
      */
     public function __construct(
-        private \DateTimeInterface $expiresAt,
-        private string $uri,
-        private int $generatedAt,
+        private readonly DateTimeInterface $expiresAt,
+        private readonly string $uri,
+        private readonly int $generatedAt,
     ) {
     }
 
@@ -43,7 +47,7 @@ final class VerifyEmailSignatureComponents
     /**
      * Get the length of time in seconds that a signature is valid for.
      */
-    public function getExpiresAt(): \DateTimeInterface
+    public function getExpiresAt(): DateTimeInterface
     {
         return $this->expiresAt;
     }
@@ -101,9 +105,9 @@ final class VerifyEmailSignatureComponents
      *
      * @throws VerifyEmailRuntimeException
      */
-    public function getExpiresAtIntervalInstance(): \DateInterval
+    public function getExpiresAtIntervalInstance(): DateInterval
     {
-        $createdAtTime = \DateTimeImmutable::createFromFormat('U', (string) $this->generatedAt);
+        $createdAtTime = DateTimeImmutable::createFromFormat('U', (string) $this->generatedAt);
 
         if (false === $createdAtTime) {
             throw new VerifyEmailRuntimeException(\sprintf('Unable to create DateTimeInterface instance from "generatedAt": %s', $this->generatedAt));

--- a/src/SymfonyCastsVerifyEmailBundle.php
+++ b/src/SymfonyCastsVerifyEmailBundle.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the SymfonyCasts VerifyEmailBundle package.
  * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace SymfonyCasts\Bundle\VerifyEmail;
 
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;

--- a/src/Util/VerifyEmailQueryUtility.php
+++ b/src/Util/VerifyEmailQueryUtility.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the SymfonyCasts VerifyEmailBundle package.
  * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace SymfonyCasts\Bundle\VerifyEmail\Util;
 
 /**

--- a/src/VerifyEmailHelper.php
+++ b/src/VerifyEmailHelper.php
@@ -1,14 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the SymfonyCasts VerifyEmailBundle package.
  * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace SymfonyCasts\Bundle\VerifyEmail;
 
+use DateTimeImmutable;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -23,7 +25,7 @@ use SymfonyCasts\Bundle\VerifyEmail\Model\VerifyEmailSignatureComponents;
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
  */
-final class VerifyEmailHelper implements VerifyEmailHelperInterface
+final readonly class VerifyEmailHelper implements VerifyEmailHelperInterface
 {
     /**
      * @param int $lifetime The length of time in seconds that a signed URI is valid for after it is created
@@ -51,7 +53,7 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
 
         $signature = $this->uriSigner->sign($uri);
 
-        if (!$expiresAt = \DateTimeImmutable::createFromFormat('U', (string) $expiryTimestamp)) {
+        if (!$expiresAt = DateTimeImmutable::createFromFormat('U', (string) $expiryTimestamp)) {
             throw new VerifyEmailRuntimeException(\sprintf('Unable to create DateTimeImmutable from timestamp: %s', $expiryTimestamp));
         }
 

--- a/src/VerifyEmailHelperInterface.php
+++ b/src/VerifyEmailHelperInterface.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the SymfonyCasts VerifyEmailBundle package.
  * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace SymfonyCasts\Bundle\VerifyEmail;
 
 use Symfony\Component\HttpFoundation\Request;

--- a/tests/Integration/VerifyEmailBundleAutowireTest.php
+++ b/tests/Integration/VerifyEmailBundleAutowireTest.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the SymfonyCasts VerifyEmailBundle package.
  * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace SymfonyCasts\Bundle\VerifyEmail\Tests\Integration;
 
 use PHPUnit\Framework\TestCase;
@@ -39,7 +40,4 @@ final class VerifyEmailBundleAutowireTest extends TestCase
 
 class VerifyEmailHelperAutowireTest
 {
-    public function __construct(VerifyEmailHelperInterface $helper) /** @phpstan-ignore-line constructor.unusedParameter */
-    {
-    }
 }

--- a/tests/Integration/VerifyEmailServiceDefinitionTest.php
+++ b/tests/Integration/VerifyEmailServiceDefinitionTest.php
@@ -1,14 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the SymfonyCasts VerifyEmailBundle package.
  * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace SymfonyCasts\Bundle\VerifyEmail\Tests\Integration;
 
+use Generator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -20,7 +22,7 @@ use SymfonyCasts\Bundle\VerifyEmail\Tests\VerifyEmailTestKernel;
  */
 final class VerifyEmailServiceDefinitionTest extends TestCase
 {
-    public function bundleServiceDefinitionDataProvider(): \Generator
+    public function bundleServiceDefinitionDataProvider(): Generator
     {
         $prefix = 'symfonycasts.verify_email.';
 

--- a/tests/VerifyEmailTestKernel.php
+++ b/tests/VerifyEmailTestKernel.php
@@ -1,14 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the SymfonyCasts VerifyEmailBundle package.
  * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace SymfonyCasts\Bundle\VerifyEmail\Tests;
 
+use Override;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -32,8 +34,8 @@ class VerifyEmailTestKernel extends Kernel
      */
     public function __construct(
         private ?ContainerBuilder $builder = null,
-        private array $routes = [],
-        private array $extraBundles = [],
+        private readonly array $routes = [],
+        private readonly array $extraBundles = [],
     ) {
         parent::__construct('test', true);
     }
@@ -51,13 +53,13 @@ class VerifyEmailTestKernel extends Kernel
 
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
-        if (null === $this->builder) {
+        if (!$this->builder instanceof ContainerBuilder) {
             $this->builder = new ContainerBuilder();
         }
 
         $builder = $this->builder;
 
-        $loader->load(function (ContainerBuilder $container) use ($builder) {
+        $loader->load(function (ContainerBuilder $container) use ($builder): void {
             $container->merge($builder);
             $container->loadFromExtension(
                 'framework',
@@ -92,11 +94,13 @@ class VerifyEmailTestKernel extends Kernel
         return $routes;
     }
 
+    #[Override]
     public function getCacheDir(): string
     {
         return sys_get_temp_dir().'/cache'.spl_object_hash($this);
     }
 
+    #[Override]
     public function getLogDir(): string
     {
         return sys_get_temp_dir().'/logs'.spl_object_hash($this);


### PR DESCRIPTION
Applied rules:

DeclareStrictTypes

ReadOnlyProperty

ReadOnlyClass

CatchExceptionNameMatchingType

FlipTypeControlToUseExclusiveType

AddOverrideAttributeToOverriddenMethods

AddClosureVoidReturnTypeWhereNoReturn

RemoveEmptyClassMethod

RemoveUnusedConstructorParam