### PR TITLE
Removal of some chars in tokens which can cause problems when sent via email (plus, slash, equals)

### DIFF
--- a/src/Generator/VerifyEmailTokenGenerator.php
+++ b/src/Generator/VerifyEmailTokenGenerator.php
@@ -40,7 +40,8 @@ class VerifyEmailTokenGenerator
     }
 
     /**
-     * Same as createToken but removes/replaces chars that could be problematic in urls
+     * Same as createToken but removes/replaces chars that could be problematic in urls.
+     *
      * @see self::createToken
      */
     public function createUrlEncodedToken(string $userId, string $email): string

--- a/src/Generator/VerifyEmailTokenGenerator.php
+++ b/src/Generator/VerifyEmailTokenGenerator.php
@@ -38,4 +38,13 @@ class VerifyEmailTokenGenerator
 
         return base64_encode(hash_hmac('sha256', $encodedData, $this->signingKey, true));
     }
+
+    /**
+     * Same as createToken but removes/replaces chars that could be problematic in urls
+     * @see self::createToken
+     */
+    public function createUrlEncodedToken(string $userId, string $email): string
+    {
+        return strtr(rtrim($this->createToken($userId, $email), '='), ['/' => '_', '+' => '-']);
+    }
 }

--- a/src/VerifyEmailHelper.php
+++ b/src/VerifyEmailHelper.php
@@ -58,7 +58,7 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
         $generatedAt = time();
         $expiryTimestamp = $generatedAt + $this->lifetime;
 
-        $extraParams['token'] = $this->tokenGenerator->createToken($userId, $userEmail);
+        $extraParams['token'] = $this->tokenGenerator->createUrlEncodedToken($userId, $userEmail);
         $extraParams['expires'] = $expiryTimestamp;
 
         $uri = $this->router->generate($routeName, $extraParams, UrlGeneratorInterface::ABSOLUTE_URL);
@@ -83,9 +83,10 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
         }
 
         $knownToken = $this->tokenGenerator->createToken($userId, $userEmail);
+        $knownEncodedToken = $this->tokenGenerator->createUrlEncodedToken($userId, $userEmail);
         $userToken = $this->queryUtility->getTokenFromQuery($signedUrl);
 
-        if (!hash_equals($knownToken, $userToken)) {
+        if (!hash_equals($knownToken, $userToken) && !hash_equals($knownEncodedToken, $userToken)) {
             throw new WrongEmailVerifyException();
         }
     }
@@ -106,8 +107,12 @@ final class VerifyEmailHelper implements VerifyEmailHelperInterface
         }
 
         $knownToken = $this->tokenGenerator->createToken($userId, $userEmail);
+        $knownEncodedToken = $this->tokenGenerator->createUrlEncodedToken($userId, $userEmail);
 
-        if (!hash_equals($knownToken, $request->query->getString('token'))) {
+        if (
+            !hash_equals($knownToken, $request->query->getString('token'))
+            && !hash_equals($knownEncodedToken, $request->query->getString('token'))
+        ) {
             throw new WrongEmailVerifyException();
         }
     }

--- a/tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
+++ b/tests/AcceptanceTests/VerifyEmailAcceptanceTest.php
@@ -47,7 +47,7 @@ final class VerifyEmailAcceptanceTest extends TestCase
         $expected = $testHelper->uriSigner->sign(\sprintf(
             'http://localhost/verify/user?expires=%s&token=%s',
             $expiresAt,
-            $testHelper->generator->createToken('1234', 'jr@rushlow.dev')
+            $testHelper->generator->createUrlEncodedToken('1234', 'jr@rushlow.dev')
         ));
 
         self::assertSame($expected, $actual);

--- a/tests/FunctionalTests/VerifyEmailHelperFunctionalTest.php
+++ b/tests/FunctionalTests/VerifyEmailHelperFunctionalTest.php
@@ -77,7 +77,12 @@ final class VerifyEmailHelperFunctionalTest extends TestCase
 
     private function getTestToken(): string
     {
-        return base64_encode(hash_hmac('sha256', json_encode(['1234', 'jr@rushlow.dev']), 'foo', true));
+        return strtr(rtrim(base64_encode(hash_hmac(
+            'sha256',
+            json_encode(['1234', 'jr@rushlow.dev']),
+            'foo',
+            true
+        )), '='), ['/' => '_', '+' => '-']);
     }
 
     private function getTestSignature(): string

--- a/tests/UnitTests/VerifyEmailHelperTest.php
+++ b/tests/UnitTests/VerifyEmailHelperTest.php
@@ -63,7 +63,7 @@ final class VerifyEmailHelperTest extends TestCase
 
         $this->tokenGenerator
             ->expects($this->once())
-            ->method('createToken')
+            ->method('createUrlEncodedToken')
             ->with('1234', 'jr@rushlow.dev')
             ->willReturn('hashedToken')
         ;
@@ -167,7 +167,7 @@ final class VerifyEmailHelperTest extends TestCase
         ;
 
         $this->tokenGenerator
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('createToken')
             ->with('1234', 'jr@rushlow.dev')
             ->willReturn(base64_encode(hash_hmac('sha256', 'data', 'foo', true)))


### PR DESCRIPTION
The current createToken method can create tokens which include chars that can cause some encoding issues later (e.g. "+", "/" and the trailing "="). Symfony's UrlSigner has already adapted a fix for that, see [here](https://github.com/symfony/http-foundation/commit/9e485dd3094b0bcf2d9cd9f9b822ef7ebc0e5dbc#diff-fa94da02681712847ba03d58c50a0ecbc38fa85bed5f286475d2f204b383e056R107).

I was a bit confused that this problem is not more widespread. Maybe it is because of some setup of our mail service... There seems to have been someone with a similar problem some time ago here #135 , but the user seems to have fixed it on their end. 

We are seeing these problems when a generated token includes "+" or "/" in the URL. These result in something like this as token parameter in the URL:

    exP7Pj6w%2BxqVTKG14YRwYxT%2FJXioLsnZhYG%2FKfHKQN8%3D

After sending this mail through our mail service in production, the url will be changed to: 

    exP7Pj6w%20xqVTKG14YRwYxT%2FJXioLsnZhYG%2FKfHKQN8

This must be some automatic encoding/parsing from the service itself, but since there might be other people using similar settings, UrlSigner also used these changes and there is no real loss in the change, it might be a good idea to implement it :)

Lastly, i have implemented it in a way, that already generated and sent token links will still work after an update. That might not really be needed though, idk.

If anyone finds this here because he has the same problems, if you are using it in a normal symfony application you can override the Generator this way (services.yaml):

    services:
      'symfonycasts.verify_email.token_generator':
          class: App\Security\UrlSafeVerifyEmailTokenGenerator
          arguments:
              $key: '%kernel.secret%'

And create a class like this:

    namespace App\Security;
    
    use SymfonyCasts\Bundle\VerifyEmail\Generator\VerifyEmailTokenGenerator;
    
    class UrlSafeVerifyEmailTokenGenerator extends VerifyEmailTokenGenerator
    {
        public function createToken(string $userId, string $email): string
        {
            return strtr(rtrim(parent::createToken($userId, $email), '='), ['/' => '_', '+' => '-']);
        }
    }

**Be advised of course that tokens that were already sent via mail before patching, will not work anymore.**